### PR TITLE
fix: pass the body as string regardless of it is json

### DIFF
--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -71,11 +71,6 @@ local function get_body(bufnr, start_line, stop_line)
     end
   end
 
-  local is_json, json_body = pcall(vim.fn.json_decode, body)
-  if is_json then
-    return json_body
-  end
-
   return body
 end
 -- is_request_line checks if the given line is a http request line according to RFC 2616


### PR DESCRIPTION
fix: pass the body as string regardless of it is json   else we hit errors in plenary.

In Plenary we can set the "body" as a string (either filename or the actual content of the payload)
or as a table in which case it is passed as `curl --data` . According to the doc, the latter does:
```
        -d, --data <data>
                  (HTTP MQTT) Sends the specified data in a POST request to the HTTP server, in the same way that a browser does when a user has filled in an HTML form and presses the submit button. This will cause curl to pass the data to the server using the content-type application/x-www-form-urlencoded. Compare
                  to -F, --form.
```
Currently rest.nvim sends a table when the file is a json one which makes no sense as per curl doc so always send it as a string (aka as "content")

    The relevant plenary code;
    https://github.com/nvim-lua/plenary.nvim/blob/1da13add868968802157a0234136d5b1fbc34dfe/lua/plenary/curl.lua#L183-L197