### PR TITLE
feat: Add option for json env and allow manipulating env files during the session

### DIFF
--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -43,6 +43,7 @@ FEATURES                                                   *rest-nvim-features*
 - Run request under cursor
 - Syntax highlight for http files and output
 - Possibility of using environment variables in http files
+- Set environment variables based on the response
 
 
 ===============================================================================
@@ -118,6 +119,9 @@ COMMANDS                                             *rest-nvim-usage-commands*
   Same as `RestNvim` but it returns the cURL command without executing the
   request. Intended for debugging purposes.
 
+- `:RestSelectEnv path/to/env`
+  Set the path to an env file.
+
 
 ===============================================================================
 REQUESTS                                             *rest-nvim-usage-requests*
@@ -151,6 +155,40 @@ These environment variables can be obtained from:
     - File in the current working directory (env_file in config or '.env')
     - System
 
+Environment variables can be set in .env format or in json.
+
+To change the environment for the session use :RestSelectEnv path/to/environment
+
+Environment variables can be set dynamically from the response body. 
+(see rest-nvim-usage-dynamic-variables)
+
+
+===============================================================================
+RESPONSE SCRIPT                                     *rest-nvim-response-script*
+
+A lua script can be run after a request has completed. This script must below
+the body and wrapped in {% script %}. A context table is avaliable in the 
+response script. The context table can be used to read the response and set
+environment variables. 
+
+The context table:
+`{`
+`  result = res,`
+`  pretty_print = vim.pretty_print,`
+`  json_decode = vim.fn.json_decode,`
+`  set_env = utils.set_env,`
+`}`
+
+Now environment variables can be set like so:
+ 
+`GET https://jsonplaceholder.typicode.com/posts/3`
+` `
+`{%` 
+` `
+`local body = context.json_decode(context.result.body)`
+`context.set_env("postId", body.id)`
+` `
+`%}`
 
 ===============================================================================
 DYNAMIC VARIABLES                           *rest-nvim-usage-dynamic-variables*

--- a/doc/tags
+++ b/doc/tags
@@ -6,6 +6,7 @@ rest-nvim-intro	rest-nvim.txt	/*rest-nvim-intro*
 rest-nvim-issues	rest-nvim.txt	/*rest-nvim-issues*
 rest-nvim-license	rest-nvim.txt	/*rest-nvim-license*
 rest-nvim-quick-start	rest-nvim.txt	/*rest-nvim-quick-start*
+rest-nvim-response-script	rest-nvim.txt	/*rest-nvim-response-script*
 rest-nvim-usage	rest-nvim.txt	/*rest-nvim-usage*
 rest-nvim-usage-commands	rest-nvim.txt	/*rest-nvim-usage-commands*
 rest-nvim-usage-dynamic-variables	rest-nvim.txt	/*rest-nvim-usage-dynamic-variables*

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -51,7 +51,7 @@ M.get_or_create_buf = function()
   return new_bufnr
 end
 
-local function create_callback(method, url)
+local function create_callback(method, url, script_str)
   return function(res)
     if res.exit ~= 0 then
       log.error("[rest.nvim] " .. utils.curl_error(res.exit))
@@ -65,6 +65,21 @@ local function create_callback(method, url)
       if string.lower(header):find("^content%-type") then
         content_type = header:match("application/(%l+)") or header:match("text/(%l+)")
         break
+      end
+    end
+
+    if script_str ~= nil then
+      local context = {
+        result = res,
+        pretty_print = vim.pretty_print,
+        json_decode = vim.fn.json_decode,
+        set_env = utils.set_env,
+      }
+      local env = { context = context }
+      setmetatable(env, { __index = _G })
+      local f = load(script_str, nil, "bt", env)
+      if f ~= nil then
+        f()
       end
     end
 
@@ -212,7 +227,7 @@ M.curl_cmd = function(opts)
     vim.api.nvim_echo({ { "[rest.nvim] Request preview:\n", "Comment" }, { curl_cmd } }, false, {})
     return
   else
-    opts.callback = vim.schedule_wrap(create_callback(opts.method, opts.url))
+    opts.callback = vim.schedule_wrap(create_callback(opts.method, opts.url, opts.script_str))
     curl[opts.method](opts)
   end
 end

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -56,8 +56,8 @@ end
 rest.run_request = function(req, opts)
   local result = req
   opts = vim.tbl_deep_extend(
-    "force",  -- use value from rightmost map
-    {verbose = false},  -- defaults
+    "force", -- use value from rightmost map
+    { verbose = false }, -- defaults
     opts or {}
   )
 
@@ -74,6 +74,7 @@ rest.run_request = function(req, opts)
     bufnr = result.bufnr,
     start_line = result.start_line,
     end_line = result.end_line,
+    script_str = result.script_str,
   }
 
   if not opts.verbose then
@@ -117,5 +118,14 @@ rest.last = function()
 end
 
 rest.request = request
+
+rest.select_env = function(path)
+  if path ~= nil then
+    vim.validate({ path = { path, "string" } })
+    config.set({ env_file = path })
+  else
+    print("No path given")
+  end
+end
 
 return rest

--- a/plugin/rest-nvim.vim
+++ b/plugin/rest-nvim.vim
@@ -8,6 +8,9 @@ if exists('g:loaded_rest_nvim') | finish | endif
 nnoremap <Plug>RestNvim :lua require('rest-nvim').run()<CR>
 nnoremap <Plug>RestNvimPreview :lua require('rest-nvim').run(true)<CR>
 nnoremap <Plug>RestNvimLast :lua require('rest-nvim').last()<CR>
+" nnoremap <Plug>RestNvimSelectEnv :lua require('rest-nvim').last()<CR>
+
+command! -nargs=? -complete=file RestSelectEnv :lua require('rest-nvim').select_env(<f-args>)<cr>
 
 let s:save_cpo = &cpo
 set cpo&vim

--- a/tests/post_create_user.http
+++ b/tests/post_create_user.http
@@ -7,5 +7,5 @@ Content-Type: application/json
     "array": ["a", "b", "c"],
     "object_ugly_closing": {
       "some_key": "some_value"
-}
+  }
 }

--- a/tests/script_vars/.env
+++ b/tests/script_vars/.env
@@ -1,0 +1,2 @@
+postId=3
+userId=1

--- a/tests/script_vars/script_vars.http
+++ b/tests/script_vars/script_vars.http
@@ -1,0 +1,15 @@
+# Should write the returned variables to the env file.
+# Then the second request can be run
+GET https://jsonplaceholder.typicode.com/posts/3
+
+{% 
+
+local body = context.json_decode(context.result.body)
+
+context.set_env("userId", body.userId)
+context.set_env("postId", body.id)
+
+%}
+
+###
+GET https://jsonplaceholder.typicode.com/posts/{{postId}}

--- a/tests/swappable_env/.env
+++ b/tests/swappable_env/.env
@@ -1,0 +1,2 @@
+TITLE=Title from .env
+BODY=Body from .env

--- a/tests/swappable_env/.env.json
+++ b/tests/swappable_env/.env.json
@@ -1,0 +1,1 @@
+{"userId": 1, "TITLE": "Json TITLE", "postId": 3, "BODY": "This Body is from the json env"}

--- a/tests/swappable_env/swappable_env.http
+++ b/tests/swappable_env/swappable_env.http
@@ -1,0 +1,10 @@
+# Use command :RestSelectEnv ./tests/swappable_env/.env.json
+# to select the env file for this request
+POST https://jsonplaceholder.typicode.com/posts
+Content-type: application/json
+
+{
+    "title": "{{TITLE}}",
+    "body": "{{BODY}}",
+    "userId": 1
+}


### PR DESCRIPTION
This addresses [#110](https://github.com/NTBBloodbath/rest.nvim/issues/110) as well as allowing the env files to be updated using a lua script inside {% script %} tags, similar to the intellij rest client. The lua code in the script tag will is passed a context table which includes the response, json_decode and a function to write/set environment variables. This is mostly useful for myself when I am working with authenticated apis.

example: 
```
POST https://jsonplaceholder.typicode.com/posts

{
  title: 'foo',
  body: 'bar',
  userId: 1,
}

{% 

local body = context.json_decode(context.result.body)
context.set_env("postId", body.id)

%}

PATCH https://jsonplaceholder.typicode.com/posts/{{postId}}

{
  title: 'foo',
}
```

Environment files can also easily be swapped using the :RestSelectEnv command meaning you can have a .env.staging and a .env.production or a staging.env.json and a production.env.json. 