### PR TITLE
Feature/support request with host

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -22,6 +22,8 @@ rest.run = function(verbose)
   Opts = {
     method = result.method:lower(),
     url = result.url,
+    -- plenary.curl can't set http protocol version
+    -- http_version = result.http_version,
     headers = result.headers,
     raw = config.get("skip_ssl_verification") and { "-k" } or nil,
     body = result.body,
@@ -44,7 +46,7 @@ rest.run = function(verbose)
   if not success_req then
     vim.api.nvim_err_writeln(
       "[rest.nvim] Failed to perform the request.\nMake sure that you have entered the proper URL and the server is running.\n\nTraceback: "
-        .. req_err
+      .. req_err
     )
   end
 end
@@ -65,7 +67,7 @@ rest.last = function()
   if not success_req then
     vim.api.nvim_err_writeln(
       "[rest.nvim] Failed to perform the request.\nMake sure that you have entered the proper URL and the server is running.\n\nTraceback: "
-        .. req_err
+      .. req_err
     )
   end
 end

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -167,7 +167,13 @@ end
 -- parse_url returns a table with the method of the request and the URL
 -- @param stmt the request statement, e.g., POST http://localhost:3000/foo
 local function parse_url(stmt)
-  local parsed = utils.split(stmt, " ")
+  -- remove HTTP
+  local parsed = utils.split(stmt, " HTTP/")
+  local http_version = nil
+  if parsed[2] ~= nil then
+    http_version = parsed[2]
+  end
+  parsed = utils.split(parsed[1], " ")
   local http_method = parsed[1]
   table.remove(parsed, 1)
   local target_url = table.concat(parsed, " ")
@@ -176,6 +182,7 @@ local function parse_url(stmt)
     method = http_method,
     -- Encode URL
     url = utils.encode_url(utils.replace_vars(target_url)),
+    http_version = http_version
   }
 end
 
@@ -212,6 +219,7 @@ M.get_current_request = function()
   return {
     method = parsed_url.method,
     url = parsed_url.url,
+    http_version = parsed_url.http_version,
     headers = headers,
     body = body,
     bufnr = bufnr,

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -20,8 +20,8 @@ local function get_importfile_name(bufnr, start_line, stop_line)
     local fileimport_line
     fileimport_line = vim.api.nvim_buf_get_lines(bufnr, import_line - 1, import_line, false)
     fileimport_string = string.gsub(fileimport_line[1], "<", "", 1)
-      :gsub("^%s+", "")
-      :gsub("%s+$", "")
+        :gsub("^%s+", "")
+        :gsub("%s+$", "")
     -- local fileimport_path = path:new(fileimport_string)
     -- if fileimport_path:is_absolute() then
     if path:new(fileimport_string):is_absolute() then
@@ -78,6 +78,7 @@ local function get_body(bufnr, start_line, stop_line)
 
   return body
 end
+
 -- is_request_line checks if the given line is a http request line according to RFC 2616
 local function is_request_line(line)
   local http_methods = { "GET", "POST", "PUT", "PATCH", "DELETE" }
@@ -192,6 +193,13 @@ M.get_current_request = function()
   local parsed_url = parse_url(vim.fn.getline(start_line))
 
   local headers, body_start = get_headers(bufnr, start_line, end_line)
+
+  if headers['host'] ~= nil then
+    headers['host'] = headers['host']:gsub("%s+", "")
+    headers['host'] = string.gsub(headers['host'], "%s+", "")
+    parsed_url.url = headers['host'] .. parsed_url.url
+    headers['host'] = nil
+  end
 
   local body = get_body(bufnr, body_start, end_line)
 

--- a/tests/get_with_host.http
+++ b/tests/get_with_host.http
@@ -1,0 +1,2 @@
+GET /api/users?page=5
+Host: https://reqres.in

--- a/tests/get_with_host.http
+++ b/tests/get_with_host.http
@@ -1,11 +1,29 @@
 ###
-# test with Host
 
 GET /api/users?page=5
 Host: https://reqres.in
 
 ###
-# test with port
+
+GET /api/users?page=5 HTTP/1.1
+Host: reqres.in:443
+
+###
+
+GET /api/users?page=5 HTTP/1.1
+Host: reqres.in:80
+
+###
+
+GET /api/users?page=5 HTTP/1.1
+Host: reqres.in
+
+###
+
+GET /api/users?page=5 HTTP/1.1
+Host: https://reqres.in:443
+
+###
 
 GET /api/users?page=5
 Host: https://reqres.in:443

--- a/tests/get_with_host.http
+++ b/tests/get_with_host.http
@@ -1,2 +1,11 @@
+###
+# test with Host
+
 GET /api/users?page=5
 Host: https://reqres.in
+
+###
+# test with port
+
+GET /api/users?page=5
+Host: https://reqres.in:443


### PR DESCRIPTION
Add support request with host

``` HTTP
GET /api/users?page=5
Host: https://reqres.in
```

Below we can add HTTP protocol version in the line.
but rest.nvim will not send HTTP/1.1 to plenary.curl because plenary.curl not support to set HTTP protocol version.
we will add support for this feature in future.
``` HTTP
GET /api/users?page=5 HTTP/1.1
Host: https://reqres.in
```

Issues: https://github.com/NTBBloodbath/rest.nvim/issues/121