### PR TITLE
rockspec: add missing dependency plenary

### DIFF
--- a/rest.nvim-scm-1.rockspec
+++ b/rest.nvim-scm-1.rockspec
@@ -15,6 +15,7 @@ description = {
 
 dependencies = {
 	"lua >= 5.1, < 5.4",
+    "plenary.nvim",
 }
 
 source = {


### PR DESCRIPTION
this wont work because I had to remove the plenary package from luarocks but it's only temporary: https://github.com/nvim-lua/plenary.nvim/pull/391
should be fine in a couple days.
