### PR TITLE
refactor file_exists function

### DIFF
--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -27,11 +27,8 @@ end
 -- file_exists checks if the provided file exists and returns a boolean
 -- @param file File to check
 M.file_exists = function(file)
-  file = io.open(file, "rb")
-  if file then
-    file:close()
-  end
-  return file ~= nil
+  if vim.fn.filereadable(file) ~= 1 then return false end
+  return true
 end
 
 -- read_file Reads all lines from a file and returns the content as a table

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -27,8 +27,7 @@ end
 -- file_exists checks if the provided file exists and returns a boolean
 -- @param file File to check
 M.file_exists = function(file)
-  if vim.fn.filereadable(file) ~= 1 then return false end
-  return true
+  return vim.fn.filereadable(file) == 1
 end
 
 -- read_file Reads all lines from a file and returns the content as a table


### PR DESCRIPTION
Since this implementation of the `file_exists` function has the ability to give an answer as to whether or not a file exists, it is not completely accurate since giving the `open` function a directory path as an argument will still return `true` indicating that the file exists even though it is not actually a file.

```lua
M.file_exists = function(file)
  file = io.open(file, "rb")
  if file then
    file:close()
  end
  return file ~= nil
end
````

so I refactored the function, making use of the built-in function`'vim.fn.filereadable`, to ensure that first we are verifying that we are actually reading a file and not a directory, and in turn showing if this file exists or not.

```lua
M.file_exists = function(file)
  if vim.fn.filereadable(file) ~= 1 then return false end
  return true
end
```

In this way when running the `read_env_file` function and there is a virtual environment (directory) with the name `.env` in the current directory, only the `.env` files will be taken into account and not the directory, preventing `io.lines` from trying to scan a directory.