### PR TITLE
Add option to skip encoding url

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ use {
       result_split_in_place = false,
       -- Skip SSL verification, useful for unknown certificates
       skip_ssl_verification = false,
+			-- Encode URL before making request
+			encode_url = true,
       -- Highlight request on run
       highlight = {
         enabled = true,
@@ -126,6 +128,7 @@ To run `rest.nvim` you should map the following commands:
     (default opens top|left on horizontal|vertical split)
 - `skip_ssl_verification` passes the `-k` flag to cURL in order to skip SSL verification,
     useful when using unknown certificates
+- `encode_url` flag to encode the URL before making request
 - `highlight` allows to enable and configure the highlighting of the selected request when send,
 - `jump_to_request` moves the cursor to the selected request line when send,
 - `env_file` specifies file name that consist environment variables (default: .env)

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -4,6 +4,7 @@ local config = {
   result_split_horizontal = false,
   result_split_in_place = false,
   skip_ssl_verification = false,
+  encode_url = true,
   highlight = {
     enabled = true,
     timeout = 150,

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -210,11 +210,16 @@ local function parse_url(stmt)
   table.remove(parsed, 1)
   local target_url = table.concat(parsed, " ")
 
+	target_url = utils.replace_vars(target_url)
+	if config.get("encode_url") then
+    -- Encode URL
+		target_url = utils.encode_url(target_url)
+	end
+
   return {
     method = http_method,
-    -- Encode URL
-    url = utils.encode_url(utils.replace_vars(target_url)),
     http_version = http_version,
+    url = target_url,
   }
 end
 


### PR DESCRIPTION
This PR provides the option to skip URL encoding the request. I ran into an issue recently where I wanted to provide the URL already encoded, but it was then getting re-encoded causing issues.

> First time contributor, open to feedback.