### PR TITLE
fix parsing of nested tables and curl arguments

### DIFF
--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -15,22 +15,15 @@ local config = {
     formatters = {
       json = "jq",
       html = function(body)
-        return vim.fn
-          .system({
-            "tidy",
-            "-i",
-            "-q",
-            "--tidy-mark",
-            "no",
-            "--show-body-only",
-            "auto",
-            "--show-errors",
-            "0",
-            "--show-warnings",
-            "0",
-            "-",
-          }, body)
-          :gsub("\n$", "")
+        -- stylua: ignore
+        return vim.fn.system({
+          "tidy", "-i", "-q",
+          "--tidy-mark",      "no",
+          "--show-body-only", "auto",
+          "--show-errors",    "0",
+          "--show-warnings",  "0",
+          "-",
+        }, body):gsub("\n$", "")
       end,
     },
   },

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -72,10 +72,18 @@ local function get_body(bufnr, start_line, stop_line, has_json)
   end
 
   local is_json, json_body = pcall(vim.fn.json_decode, body)
+
   if is_json then
     if has_json then
+      -- convert entire json body to string.
       return vim.fn.json_encode(json_body)
     else
+      -- convert nested tables to string.
+      for key, val in pairs(json_body) do
+        if type(val) == "table" then
+          json_body[key] = vim.fn.json_encode(val)
+        end
+      end
       return json_body
     end
   end

--- a/tests/post_json_form.http
+++ b/tests/post_json_form.http
@@ -10,5 +10,5 @@ POST http://localhost:8080
 	"array":  [1, 2, 3],
 	"json": {
 		"key": "value"
-	
+	}
 }

--- a/tests/post_json_form.http
+++ b/tests/post_json_form.http
@@ -1,0 +1,14 @@
+# Run:
+# $ python -m http.server 8080
+
+# it should return status code 501
+POST http://localhost:8080
+
+{
+	"string": "foo",
+	"number": 100,
+	"array":  [1, 2, 3],
+	"json": {
+		"key": "value"
+	
+}


### PR DESCRIPTION
Fixes errors when you pass array or object in request body without setting request body to `application/json`, for example:

```http
POST http://localhost:8000/login

{
  "username": "foo",
  "args": {
    "key": "val"
  }
}
```

would result in following error:
```
[rest.nvim] Failed to perform the request.
Make sure that you have entered the proper URL and the server is running.
Traceback: ...site/pack/packer/start/plenary.nvim/lua/plenary/curl.lua:54: attempt to concatenate a table value
```

but this PR fixes it and gives the following query:
```bash
curl -sSL --compressed -X 'POST' -d 'args={"key": "val"}' -d 'username=foo' 'http://localhost:8000/login'
```