### PR TITLE
Fix indentation for new `encode_url` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ use {
       result_split_in_place = false,
       -- Skip SSL verification, useful for unknown certificates
       skip_ssl_verification = false,
-			-- Encode URL before making request
-			encode_url = true,
+      -- Encode URL before making request
+      encode_url = true,
       -- Highlight request on run
       highlight = {
         enabled = true,


### PR DESCRIPTION
Swap tabs to spaces so everything is aligned. 😅 

<img width="639" alt="CleanShot 2022-09-16 at 17 06 40@2x" src="https://user-images.githubusercontent.com/3171522/190832204-2f77c530-b9d2-4557-ba45-424ad358695b.png">
