### PR TITLE
Fix get_body function

### DIFF
--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -11,7 +11,7 @@ local function get_importfile_name(bufnr, start_line, stop_line)
   local oldpos = vim.fn.getcurpos()
   utils.move_cursor(bufnr, start_line)
 
-  local import_line = vim.fn.search("^<", "n", stop_line)
+  local import_line = vim.fn.search("^<", "cn", stop_line)
   -- restore old cursor position
   utils.move_cursor(bufnr, oldpos[2])
 
@@ -43,10 +43,6 @@ end
 -- @param stop_line Line where body stops
 -- @param has_json True if content-type is set to json
 local function get_body(bufnr, start_line, stop_line, has_json)
-  if start_line >= stop_line then
-    return
-  end
-
   -- first check if the body should be imported from an external file
   local importfile = get_importfile_name(bufnr, start_line, stop_line)
   local lines
@@ -56,7 +52,7 @@ local function get_body(bufnr, start_line, stop_line, has_json)
     end
     lines = utils.read_file(importfile)
   else
-    lines = vim.api.nvim_buf_get_lines(bufnr, start_line, stop_line, false)
+    lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, stop_line, false)
   end
 
   local body = ""


### PR DESCRIPTION
## Summary 

This PR fixes `get_body` for cases when body definition has only one line.

### Problem

Files like [tests/external_file/post_create_user.http](https://github.com/rest-nvim/rest.nvim/blob/4a23d38726c0b3c5a2de9f927de5b0b518bdf4f7/tests/external_file/post_create_user.http) are not working as expected. 
When we open it and run `:lua require("rest-nvim").run(true)` the current result is
```
[rest.nvim] Request preview:
curl -sSL --compressed -X 'POST' -H 'Content-Type: application/json' 'https://reqres.in/api/users'
```

but the expected is
```
[rest.nvim] Request preview:
curl -sSL --compressed -X 'POST' -H 'Content-Type: application/json' --data-raw '{"name": "morpheus", "job": "leader", "time": "1667482599"}' 'https://reqres.in/api/users'
```