### PR TITLE
Update github references to rest-nvim/rest.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A fast Neovim http client written in Lua.
 in `plenary.nvim` so, in other words, `rest.nvim` is a curl wrapper so you don't
 have to leave Neovim!
 
-> **IMPORTANT:** If you are facing issues, please [report them](https://github.com/NTBBloodbath/rest.nvim/issues/new)
+> **IMPORTANT:** If you are facing issues, please [report them](https://github.com/rest-nvim/rest.nvim/issues/new)
 
 ## Notices
 
@@ -57,7 +57,7 @@ have to leave Neovim!
 
 ```lua
 use {
-  "NTBBloodbath/rest.nvim",
+  "rest-nvim/rest.nvim",
   requires = { "nvim-lua/plenary.nvim" },
   config = function()
     require("rest-nvim").setup({
@@ -151,7 +151,7 @@ request method (e.g. `GET`) and run `rest.nvim`.
 
 ## Contribute
 
-1. Fork it (https://github.com/NTBBloodbath/rest.nvim/fork)
+1. Fork it (https://github.com/rest-nvim/rest.nvim/fork)
 2. Create your feature branch (<kbd>git checkout -b my-new-feature</kbd>)
 3. Commit your changes (<kbd>git commit -am 'Add some feature'</kbd>)
 4. Push to the branch (<kbd>git push origin my-new-feature</kbd>)

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -218,7 +218,7 @@ SOFTWARE.
 ===============================================================================
 CONTRIBUTING                                           *rest-nvim-contributing*
 
-    1. Fork it (`github.com/NTBBloodbath/rest.nvim/fork`)
+    1. Fork it (`github.com/rest-nvim/rest.nvim/fork`)
     2. Create your feature branch (`git checkout -b my-new-feature`)
     3. Commit your changes (`git commit -am 'Add some feature'`)
     4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
This commit updates the README and doc/rest-nvim.txt with references to `rest-nvim/rest.nvim` instead of `NTBBloodbath/rest.nvim`

Other occurences of NTBBloodbath in the license were ignored for now as I'm not sure if that should be included in this PR.