### PR TITLE
fix formatter for html and error in rest.run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ use {
         show_http_info = true,
         show_headers = true,
         -- executables or functions for formatting response body [optional]
-        -- set them to nil if you want to disable them
+        -- set them to false if you want to disable them
         formatters = {
           json = "jq",
           html = function(body)

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -36,6 +36,7 @@ local config = {
   env_file = ".env",
   custom_dynamic_variables = {},
   yank_dry_run = true,
+  debug = false,
 }
 
 --- Get a configuration value

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -16,6 +16,10 @@ local config = {
     formatters = {
       json = "jq",
       html = function(body)
+        if vim.fn.executable("tidy") == 0 then
+          return body
+        end
+
         -- stylua: ignore
         return vim.fn.system({
           "tidy", "-i", "-q",

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -21,7 +21,7 @@ rest.run = function(verbose)
     return
   end
 
-  return rest.run_request(result, verbose)
+  return rest.run_request(result, {verbose = verbose})
 end
 
 -- run will retrieve the required request information from the current buffer

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -176,7 +176,9 @@ end
 -- @param bufnr The buffer nummer of the .http-file
 -- @param linenumber (number) From which line to start looking
 local function start_request(bufnr, linenumber)
-  log.debug("Searching pattern starting from " .. linenumber)
+  if config.get("debug") then
+    log.debug("Searching pattern starting from " .. linenumber)
+  end
 
   local oldlinenumber = linenumber
   utils.move_cursor(bufnr, linenumber)


### PR DESCRIPTION
Fixes error caused by html formatter running even when tidy is not available on the system. Also fixes docs related to disabling formatters.

fixes #164