### PR TITLE
fix: formatter for html and special casing of content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ use {
         show_http_info = true,
         show_headers = true,
         -- executables or functions for formatting response body [optional]
-        -- set them to nil if you want to disable them
+        -- set them to false if you want to disable them
         formatters = {
           json = "jq",
           html = function(body)

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -16,6 +16,9 @@ local config = {
     formatters = {
       json = "jq",
       html = function(body)
+        if vim.fn.executable("tidy") == 0 then
+          return body
+        end
         -- stylua: ignore
         return vim.fn.system({
           "tidy", "-i", "-q",

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -67,7 +67,7 @@ local function get_body(bufnr, start_line, stop_line, has_json)
     end
   end
 
-  local is_json, json_body = pcall(vim.fn.json_decode, body)
+  local is_json, json_body = pcall(vim.json.decode, body)
 
   if is_json then
     if has_json then
@@ -280,11 +280,20 @@ M.buf_get_request = function(bufnr, curpos)
     headers["host"] = nil
   end
 
+  local content_type = ""
+
+  for key, val in pairs(headers) do
+    if string.lower(key) == "content-type" then
+      content_type = val
+      break
+    end
+  end
+
   local body = get_body(
     bufnr,
     body_start,
     end_line,
-    string.find(headers["content-type"] or "", "application/[^ ]-json")
+    content_type:find("application/[^ ]*json")
   )
 
   if config.get("jump_to_request") then


### PR DESCRIPTION
## FIX 1
Fixes error caused by html formatter running even when tidy is not available on the system. Also fixes docs related to disabling formatters.

> This PR is a cleaner version of #165.

---

**Reason why formatter should be set to `false` instead of `nil`:**

`nil` means nothing, ie. absence of value; that's why you have how pass `false` instead which has a actual value `0` in binary which can be set to a variable and passed around.

Here's another analogy:

Let's say you asked me to put something in a box, and I put `<nothing>` in the box. Is the box now empty or does it contain `nothing`? There is no way for you to verify that.

## FIX 2

Fixes #157  hardcoded lower casing of content-type.