### PR TITLE
Add default `opts` for .run_request function

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -55,6 +55,12 @@ end
 
 rest.run_request = function(req, opts)
   local result = req
+  opts = vim.tbl_deep_extend(
+    "force",  -- use value from rightmost map
+    {verbose = false},  -- defaults
+    opts or {}
+  )
+
   Opts = {
     method = result.method:lower(),
     url = result.url,


### PR DESCRIPTION
Allow users to call `.run()` without passing `true|false` for verbose parameter.

relates #166