### PR TITLE
try to use treesitter instead

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,4 @@
+-- List of warnings at https://luacheck.readthedocs.io/en/stable/warnings.html
 -- Use lua52 so we will no receive errors regarding to goto statements
 std = 'lua52+busted'
 
@@ -6,6 +7,8 @@ cache = true
 
 ignore = {
 	'631', -- max_line_length
+    '213',
+    '214'
 }
 
 read_globals = {

--- a/.nvimrc
+++ b/.nvimrc
@@ -1,0 +1,2 @@
+set rtp+=.
+lua require'plenary.reload'.reload_module('rest-nvim')

--- a/README.md
+++ b/README.md
@@ -154,14 +154,11 @@ request method (e.g. `GET`) and run `rest.nvim`.
 
 ## Contribute
 
-1. Fork it (https://github.com/rest-nvim/rest.nvim/fork)
-2. Create your feature branch (<kbd>git checkout -b my-new-feature</kbd>)
-3. Commit your changes (<kbd>git commit -am 'Add some feature'</kbd>)
-4. Push to the branch (<kbd>git push origin my-new-feature</kbd>)
-5. Create a new Pull Request
+You can get into a development shell via `nix develop ./contrib`.
+To enable debug, `export DEBUG_PLENARY="debug"`
 
-To run the tests, enter a nix shell with `nix develop ./contrib`, then run `make
-test`.
+
+To run the tests, enter a nix shell with `nix run ./contrib#tests`.
 
 ## Related software
 

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -72,7 +72,7 @@ end
 local function create_callback(curl_cmd, method, url, script_str)
   return function(res)
     if res.exit ~= 0 then
-      log.error("[rest.nvim] " .. utils.curl_error(res.exit))
+      log.error(utils.curl_error(res.exit))
       return
     end
     local res_bufnr = M.get_or_create_buf()
@@ -92,7 +92,11 @@ local function create_callback(curl_cmd, method, url, script_str)
         pretty_print = vim.pretty_print,
         json_decode = vim.fn.json_decode,
         set_env = session.set_env,
+        -- TODO but one can set them
+        -- variables = utils.get_env_variables(),
       }
+      -- TODO should look into utils.get_env_variables for unknown variables
+      -- setmetatable(context, { __index = _G })
       local env = { context = context }
       setmetatable(env, { __index = _G })
       local f = load(script_str, nil, "bt", env)

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -2,6 +2,7 @@ local utils = require("rest-nvim.utils")
 local curl = require("plenary.curl")
 local log = require("plenary.log").new({ plugin = "rest.nvim" })
 local config = require("rest-nvim.config")
+local session = require("rest-nvim.session")
 
 local M = {}
 -- checks if 'x' can be executed by system()
@@ -90,7 +91,7 @@ local function create_callback(curl_cmd, method, url, script_str)
         result = res,
         pretty_print = vim.pretty_print,
         json_decode = vim.fn.json_decode,
-        set_env = utils.set_env,
+        set_env = session.set_env,
       }
       local env = { context = context }
       setmetatable(env, { __index = _G })

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -17,7 +17,9 @@ end
 rest.run = function(verbose)
   local ok, result = request.get_current_request()
   if not ok then
-    vim.api.nvim_err_writeln("[rest.nvim] Failed to get the current HTTP request: " .. result)
+    log.error("Failed to run the http request:")
+    log.error(result)
+    vim.api.nvim_err_writeln("[rest.nvim] Failed to get the current HTTP request: " .. tostring(result))
     return
   end
 
@@ -70,8 +72,8 @@ rest.run_request = function(req, opts)
     opts or {}
   )
 
-  print(req)
-  request.print_request(req)
+  -- print(req)
+  request.print_request(req, { full_body = true})
   Opts = {
     method = result.method:lower(),
     url = result.url,

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -42,6 +42,7 @@ rest.run_file = function(filename, opts)
   local curpos = vim.fn.getcurpos()
   while curpos[2] <= last_line do
     local ok, req = request.buf_get_request(new_buf, curpos)
+    request.print_request(req)
     if ok then
       -- request.print_request(req)
       curpos[2] = req.end_line + 1
@@ -53,14 +54,24 @@ rest.run_file = function(filename, opts)
   return true
 end
 
+
+-- run will retrieve the required request information from the current buffer
+-- and then execute curl
+-- @param req table see validate_request to check the expected format
+-- @param opts table
+--           1. keep_going boolean keep running even when last request failed
 rest.run_request = function(req, opts)
   local result = req
   opts = vim.tbl_deep_extend(
     "force", -- use value from rightmost map
-    { verbose = false }, -- defaults
+    { verbose = false,
+      highlight = false
+    }, -- defaults
     opts or {}
   )
 
+  print(req)
+  request.print_request(req)
   Opts = {
     method = result.method:lower(),
     url = result.url,
@@ -81,7 +92,7 @@ rest.run_request = function(req, opts)
     LastOpts = Opts
   end
 
-  if config.get("highlight").enabled then
+  if opts.highlight then
     request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -96,7 +96,16 @@ rest.run_request = function(req, opts)
     request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 
+  log.debug(request.stringify_request(req))
   local success_req, req_err = pcall(curl.curl_cmd, Opts)
+
+
+  -- TODO if it was successful we could move to next request
+  -- if config.get("jump_to_request") then
+  --   utils.move_cursor(bufnr, start_line)
+  -- else
+  --   utils.move_cursor(bufnr, curpos[2], curpos[3])
+  -- end
 
   if not success_req then
     vim.api.nvim_err_writeln(

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -524,19 +524,26 @@ M.buf_get_current_request = function(bufnr)
   -- old implementation
   -- return M.buf_get_request(vim.api.nvim_win_get_buf(0), vim.fn.getcurpos())
   local query_node = M.buf_get_request_at_node(bufnr, ts_utils.get_node_at_cursor())
+  print("buf_get_current_request", query_node:type())
+  if not query_node then
+    local msg = "Could not find any query"
+    vim.notify(msg)
+    log.warn(msg)
+  end
   local result = M.ts_build_request_from_node(query_node, 0)
   M.print_request(result)
   return true, result
 end
 
 M.buf_get_request_at_node = function(_bufnr, start_node)
-  local parser = ts.get_parser(0, "http")
-  local root = parser:parse()[1]:root()
-  -- local start_node = ts_utils.get_node_at_cursor()
-  -- print("start node type", start_node:type())
+  log.debug("buf_get_request_at_node")
+  -- local parser = ts.get_parser(0, "http")
+  -- local root = parser:parse()[1]:root()
+
+  print("start node type", start_node:type())
   local node = start_node
-  while node:type() ~= "query" and node ~= root do
-    -- print("node before", node:type())
+  while node ~= nil and node:type() ~= "query" do
+    print("node before", node:type())
     node = node:parent()
 
     -- node = ts_utils.get_previous_node(node, true, true)

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -391,16 +391,17 @@ M.ts_build_request_from_node = function (tsnode, bufnr)
   --
   -- local curl_args, body_start = get_curl_args(bufnr, headers_end, end_line)
 
+  local headers_end = tsnode:end_()+1
   local body = get_body(
     bufnr,
     vars,
-    tsnode:end_()+1,
+    headers_end,
     end_line,
     true -- assume json for now
     -- content_type:find("application/[^ ]*json")
   )
 
-  local script_str = get_response_script(bufnr,tsnode:end_()+1, end_line)
+  local script_str = get_response_script(bufnr,headers_end, end_line)
 
     return {
       method = vim.treesitter.query.get_node_text(methodnode, bufnr),
@@ -592,7 +593,13 @@ M.buf_get_request = function(bufnr, curpos)
       }
 end
 
+-- to remove
 M.print_request = function(req)
+  print(M.stringify_request(req))
+end
+
+-- converts request into string, helpful for debug
+M.stringify_request = function(req)
   local str = [[
     url: ]] .. req.url .. [[\n
     method: ]] .. req.method .. [[\n
@@ -600,8 +607,14 @@ M.print_request = function(req)
     end_line: ]] .. tostring(req.end_line) .. [[\n
   ]]
   if req.http_version then
-    str = "http_version: ".. req.http_version .. "\n"
+    str = str.."\nhttp_version: ".. req.http_version .. "\n"
   end
+
+  if req.body then
+    str = str.."body: "..req.body.."\n"
+  end
+
+  -- here we should just display the beginning of the request
   print(str)
 end
 

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -10,9 +10,13 @@ local parser_name = "http"
 
 local M = {}
 
+-- todo add a metatable with stringify etc
+-- local Request = {}
+
+
 -- | validate dict is conform to what is expected in an array
 -- in absence of types, that's what we can do best
-M.validate_request = function (request)
+M.validate_request = function(request)
 
   return vim.validate({ user_configs = { request, "table" } })
   -- check keys/values ?
@@ -34,23 +38,13 @@ end
 -- get_importfile returns in case of an imported file the absolute filename
 -- @param bufnr Buffer number, a.k.a id
 -- @param stop_line Line to stop searching
-local function get_importfile_name(bufnr, start_line, stop_line)
-  -- store old cursor position
-  local oldpos = vim.fn.getcurpos()
-  utils.move_cursor(bufnr, start_line)
+-- TODO load it via grammar !
+-- return complete filename
+local function load_importfile_name(_bufnr, rawfilename, vars)
+  log.debug("Loading importfile " .. rawfilename)
 
-  local import_line = vim.fn.search("^<", "cn", stop_line)
-  -- restore old cursor position
-  utils.move_cursor(bufnr, oldpos[2])
-
-  if import_line > 0 then
-    local fileimport_string
-    local fileimport_line
     local fileimport_spliced
-    fileimport_line = vim.api.nvim_buf_get_lines(bufnr, import_line - 1, import_line, false)
-    fileimport_string =
-      string.gsub(fileimport_line[1], "<", "", 1):gsub("^%s+", ""):gsub("%s+$", "")
-    fileimport_spliced = utils.replace_vars(fileimport_string)
+  fileimport_spliced = utils.replace_vars(rawfilename, vars)
     if path:new(fileimport_spliced):is_absolute() then
       return fileimport_spliced
     else
@@ -58,9 +52,11 @@ local function get_importfile_name(bufnr, start_line, stop_line)
       local file_name = path:new(path:new(file_dirname), fileimport_spliced)
       return file_name:absolute()
     end
-  end
-  return nil
 end
+
+-- print("GETTING BODY FROM ", start_line, " to ", stop_line)
+-- -- first check if the body should be imported from an external file
+-- local importfile = get_importfile_name(bufnr, start_line, stop_line)
 
 -- get_body retrieves the body lines in the buffer and then returns
 -- either a table if the body is a JSON or a raw string if it is a filename
@@ -71,7 +67,10 @@ end
 -- @param start_line Line where body starts
 -- @param stop_line Line where body stops
 -- @param has_json True if content-type is set to json
+-- luacheck: ignore unused-local unused-function
 local function get_body(bufnr, vars, start_line, stop_line, has_json)
+
+  print("GETTING BODY FROM ", start_line, " to ", stop_line)
   -- first check if the body should be imported from an external file
   local importfile = get_importfile_name(bufnr, start_line, stop_line)
   local lines
@@ -120,122 +119,43 @@ local function get_body(bufnr, vars, start_line, stop_line, has_json)
   return body
 end
 
-local function get_response_script(bufnr, start_line, stop_line)
-  local all_lines = vim.api.nvim_buf_get_lines(bufnr, start_line, stop_line, false)
-  -- Check if there is a script
-  local script_start_rel
-  for i, line in ipairs(all_lines) do
-    -- stop if a script opening tag is found
-    if line:find("{%%") then
-      script_start_rel = i
-      break
-    end
-  end
-
-  if script_start_rel == nil then
-    return nil
-  end
-
-  -- Convert the relative script line number to the line number of the buffer
-  local script_start = start_line + script_start_rel - 1
-
-  local script_lines = vim.api.nvim_buf_get_lines(bufnr, script_start, stop_line, false)
-  local script_str = ""
-
-  for _, line in ipairs(script_lines) do
-    script_str = script_str .. line .. "\n"
-    if line:find("%%}") then
-      break
-    end
-  end
-
-  return script_str:match("{%%(.-)%%}")
-end
-
--- is_request_line checks if the given line is a http request line according to RFC 2616
-local function is_request_line(line)
-  local http_methods = { "GET", "POST", "PUT", "PATCH", "DELETE" }
-  for _, method in ipairs(http_methods) do
-    if line:find("^" .. method) then
-      return true
-    end
-  end
-  return false
-end
-
--- get_headers retrieves all the found headers and returns a lua table with them
--- @param bufnr Buffer number, a.k.a id
--- @param start_line Line where the request starts
--- @param end_line Line where the request ends
-local function get_headers(bufnr, start_line, end_line)
-  local headers = {}
-  local headers_end = end_line
-
-  error("TO REMOVE")
-
-  -- Iterate over all buffer lines starting after the request line
-  for line_number = start_line + 1, end_line do
-    local line_content = vim.fn.getbufline(bufnr, line_number)[1]
-
-    -- message header and message body are seperated by CRLF (see RFC 2616)
-    -- for our purpose also the next request line will stop the header search
-    if is_request_line(line_content) or line_content == "" then
-      headers_end = line_number
-      break
-    end
-    if not line_content:find(":") then
-      log.warn("Missing Key/Value pair in message header. Ignoring line: ", line_content)
-      goto continue
-    end
-
-    local header_name, header_value = line_content:match("^(.-): ?(.*)$")
-
-    if not utils.contains_comments(header_name) then
-      headers[header_name] = utils.replace_vars(header_value)
-    end
-    ::continue::
-  end
-
-  return headers, headers_end
-end
-
 -- get_curl_args finds command line flags and returns a lua table with them
 -- @param bufnr Buffer number, a.k.a id
 -- @param headers_end Line where the headers end
 -- @param end_line Line where the request ends
-local function get_curl_args(bufnr, headers_end, end_line)
-  local curl_args = {}
-  local body_start = end_line
+-- local function get_curl_args(bufnr, headers_end, end_line)
+--   local curl_args = {}
+--   local body_start = end_line
 
-  for line_number = headers_end, end_line do
-    local line_content = vim.fn.getbufline(bufnr, line_number)[1]
+--   for line_number = headers_end, end_line do
+--     local line_content = vim.fn.getbufline(bufnr, line_number)[1]
 
-    if line_content:find("^ *%-%-?[a-zA-Z%-]+") then
-      local lc = vim.split(line_content, " ")
-      local x = ""
+--     if line_content:find("^ *%-%-?[a-zA-Z%-]+") then
+--       local lc = vim.split(line_content, " ")
+--       local x = ""
 
-      for i, y in ipairs(lc) do
-        x = x .. y
+--       for i, y in ipairs(lc) do
+--         x = x .. y
 
-        if #y:match("\\*$") % 2 == 1 and i ~= #lc then
-          -- insert space if there is an slash at end
-          x = x .. " "
-        else
-          -- insert 'x' into curl_args and reset it
-          table.insert(curl_args, x)
-          x = ""
-        end
-      end
-    elseif not line_content:find("^ *$") then
-      if line_number ~= end_line then
-        body_start = line_number - 1
-      end
-      break
-    end
-  end
+--         if #y:match("\\*$") % 2 == 1 and i ~= #lc then
+--           -- insert space if there is an slash at end
+--           x = x .. " "
+--         else
+--           -- insert 'x' into curl_args and reset it
+--           table.insert(curl_args, x)
+--           x = ""
+--         end
+--       end
+--     elseif not line_content:find("^ *$") then
+--       if line_number ~= end_line then
+--         body_start = line_number - 1
+--       end
+--       break
+--     end
+--   end
 
-  return curl_args, body_start
-end
+--   return curl_args, body_start
+-- end
 
 -- start_request will find the request line (e.g. POST http://localhost:8081/foo)
 -- of the current request and returns the linenumber of this request line.
@@ -318,60 +238,126 @@ end
 
 
 local function print_node(title, node)
-    print(string.format("%s: type '%s' isNamed '%s'", title, node:type(), node:named()))
-    print("type", node:type())
-    print("child count", node:child_count())
-
+  print(string.format("%s: type '%s' isNamed '%s' with %d children", title, node:type(), node:named()
+    , node:child_count()))
 end
 
--- TODO convert ts requests
--- TODO g
-M.get_requests = function (bufnr)
-  -- todo we'll need node.get_node_text
-  return M.ts_get_requests(bufnr)
+-- return the lua script code if any
+-- ideally we could have several
+local function ts_load_script(qnode)
+  log.debug("Loading script")
+  -- TODO
+  -- load_raw
+  print("Looking for script")
+  for node, name in qnode:iter_children() do
+    -- print("type", node:type(), "NAME: ", name)
+
+    -- wont work, it needs to be "script"
+    if node:type() == "script" then
+      -- print("type", node:type(), "NAME: ", node:named())
+      return node
+
+      -- node:field("internal_script")
+      -- local internal_script = node:child(0)
+      -- -- TODO there are lots of errors which breaks the stuff
+      -- print("number of children ", node:child_count())
+      -- print("Internal ?", vim.inspect(internal_script))
+      -- print("Internal ?", internal_script)
+      -- print_node("found internal script: ", internal_script)
+      -- return internal_script
+    end
+  end
+end
+
+
+--
+local function encode_json(body, json_ctype)
+  local is_json, json_body = pcall(vim.json.decode, body)
+
+  if is_json then
+    -- print("it is json")
+    if json_ctype then
+      print("and we have a json ctype !")
+      -- convert entire json body to string.
+      return vim.fn.json_encode(json_body)
+    else
+      -- convert nested tables to string.
+      for key, val in pairs(json_body) do
+        if type(val) == "table" then
+          json_body[key] = vim.fn.json_encode(val)
+        end
+      end
+      return vim.fn.json_encode(json_body)
+    end
+  end
+end
+
+local function ts_get_body(bufnr, qnode, vars, _has_json)
+  local lines
+  -- local body_node
+  -- iter direct children
+  log.debug("Looking for body")
+  for node, _name in qnode:iter_children(qnode) do
+    -- print("type", node:type(), "NAME: ", name)
+    if node:type() == "body" then
+      -- there should be only one child ?
+      local body = node:child(0)
+      local payload_file_fields = body:field("payload_file")
+      -- print("number of children ", body:type())
+      -- print("number of fields payload_file ", vim.inspect(body:field("payload_file")))
+      if #payload_file_fields > 0 then
+        local payload_file_node = payload_file_fields[1]
+        print_node("payload file node ?", payload_file_node)
+        -- print_node("found payload node: ", node)
+        -- replace the filename with variables than load the file
+        local raw_filename = vim.treesitter.query.get_node_text(payload_file_node, bufnr)
+        -- local final_filename = utils.replace_vars(raw_filename, vars)
+        -- TODO move code ?
+        local importfile = load_importfile_name(bufnr, raw_filename, vars)
+        if importfile ~= nil then
+          if not utils.file_exists(importfile) then
+            error("import file " .. importfile .. " not found")
+          end
+          lines = utils.read_file(importfile)
+          -- print("LINES", lines)
+          local res = encode_json(table.concat(lines, "\n"),_has_json)
+          return res
+          -- return lines
+        end
+      end
+
+    end
+  end
 end
 
 -- Build a rest.nvim request from a treesitter query
 -- @param node a treeitter node of type "query" TODO assert/check
 -- @param bufnr
-M.ts_build_request_from_node = function (tsnode, bufnr)
+M.ts_build_request_from_node = function(reqnode, bufnr)
+  assert(reqnode:type() == "query")
 
-  print('building request_from_node')
+  -- log.debug('building request_from_node')
   local vars = utils.read_variables()
 
   -- named_child(0)
-  local reqnode = tsnode:child(0)
-  local id = "toto"
+  -- local reqnode = tsnode:child(0)
+  -- local id = "toto"
   print_node("reqnode", reqnode)
 
-  -- :field("method")[1]
-  -- print("id", id , "isNamed" .. tostring(tsnode:named()))
-  print_node(string.format("- capture node id(%s)", id), tsnode)
-  -- print("node count ", tsnode:named_child_count())
-
-  -- print("node method ", tsnode:field("url"))
-  -- tsnode:field({name})
   -- Returns a table of the nodes corresponding to the {name} field.
-  local methodfields = tsnode:field("request")
-  -- :field("method")
-  -- print("number of request fields ? ", #methodfields)
-  -- print("first request field ? ", methodfields[1])
+  local methodfields = reqnode:field("request")
   local methodnode = methodfields[1]:field("method")[1]
   local urlnode = methodfields[1]:field('url')[1]
-  -- print("methodnode", methodnode:field('method')[1])
-  -- print("urlnode", methodfields[2])
   print("url content ?", vim.treesitter.query.get_node_text(urlnode, bufnr))
-  local start_line = vim.treesitter.query.get_node_text(methodnode, bufnr)
-  print("parsing start_line: ", start_line)
-  -- TODO could parse just the URL since the method is already given by ts
-
-  -- local parsed_url = parse_url(start_line)
   local url = vim.treesitter.query.get_node_text(urlnode, bufnr)
   url = utils.replace_vars(url, vars)
 
-
   -- TODO splice header variables/pass variables
-  local headers = M.ts_get_headers(tsnode, bufnr)
+  local headers = M.ts_get_headers(reqnode, bufnr)
+  local headers_spliced = {}
+  for name, value in pairs(headers) do
+    headers_spliced[name] = utils.replace_vars(value, vars)
+  end
 
   -- if not utils.contains_comments(header_name) then
   --   headers[header_name] = utils.replace_vars(header_value)
@@ -379,54 +365,94 @@ M.ts_build_request_from_node = function (tsnode, bufnr)
 
   -- HACK !!!
   -- Because we have trouble catching the body through tree-sitter
-  -- we just look set the end_line to the (beginning -1) line of the next request 
+  -- we just look set the end_line to the (beginning -1) line of the next request
   -- or the last line if there are no other requests
   local end_line = vim.fn.line("$")
-  local nextreq = tsnode:next_sibling()
-  print_node("next query", nextreq)
+
+  -- TODO look for next_sibling of same type query
+  local nextreq = reqnode:next_sibling()
+  while nextreq and nextreq:type() ~= "query" do
+    nextreq = nextreq:next_sibling()
+  end
+
+  -- print_node("reqnode ", reqnode)
+  -- print_node("next query", nextreq)
   if nextreq then
-    end_line = nextreq:end_()
+    -- print("Found another sibling", nextreq:id())
+    -- print_node("final nextreq", nextreq)
+    end_line = nextreq:start() - 1
+  else
+    print("found no other sibling")
   end
 
   --
   -- local curl_args, body_start = get_curl_args(bufnr, headers_end, end_line)
+  local script_str
+  local script_node = ts_load_script(reqnode)
+  if script_node then
+    script_str = vim.treesitter.query.get_node_text(script_node, bufnr)
 
-  local headers_end = tsnode:end_()+1
-  local body = get_body(
+    -- THIS IS A HACK until I can retrieve internal_script properly !
+    script_str = script_str:match("{%%(.-)%%}")
+    print("using SCRIPT_STR:", script_str)
+
+    log.debug("Using script_str", script_str)
+  end
+
+  -- sounds like a bug, it should be + 1 ?
+  -- local headers_end = reqnode:end_() + 2
+
+  -- TODO wip
+  local body = ts_get_body(
     bufnr,
+    reqnode,
     vars,
-    headers_end,
-    end_line,
-    true -- assume json for now
-    -- content_type:find("application/[^ ]*json")
+    -- TODO assume json for now but we should look at headers ctype
+    true
   )
 
-  local script_str = get_response_script(bufnr,headers_end, end_line)
+  -- load the body
+  -- if script_node then
+  --   script_str = vim.treesitter.query.get_node_text(script_node, bufnr)
+  -- end
 
-    return {
-      method = vim.treesitter.query.get_node_text(methodnode, bufnr),
-      url = url,
-      -- TODO found from parse_url but should use ts as well:
-      -- methodnode:field('http_version')[1],
-      http_version = nil,
-      headers = headers,
-      -- TODO build curl_args from 'headers'
-      -- I dont really care about that so I left it 
-      raw = nil,
-      -- TODO check if body is full string ?
-      body = body,
-      bufnr = bufnr,
-      start_line = tsnode:start(),
-      -- le end line is computed
-      end_line = end_line,
-      -- todo
-      script_str = script_str
+  -- local body = get_body(
+  --   bufnr,
+  --   vars,
+  --   headers_end,
+  --   end_line,
+  --   true -- assume json for now
+  --   -- content_type:find("application/[^ ]*json")
+  -- )
 
-    }
+  print("RETURNED BODY", body)
+
+  -- local script_str = get_response_script(bufnr,headers_end, end_line)
+
+  return {
+    method = vim.treesitter.query.get_node_text(methodnode, bufnr),
+    url = url,
+    -- TODO found from parse_url but should use ts as well:
+    -- methodnode:field('http_version')[1],
+    http_version = nil,
+    headers = headers_spliced,
+    -- TODO build curl_args from 'headers'
+    -- I dont really care about that so I left it
+    raw = nil,
+    -- TODO check if body is full string ?
+    body = body,
+    bufnr = bufnr,
+    start_line = reqnode:start(),
+    -- le end line is computed
+    end_line = end_line,
+    -- todo
+    script_str = script_str
+
+  }
 end
 
 -- TODO we should return headers for query
-M.ts_get_headers = function (qnode, bufnr)
+M.ts_get_headers = function(qnode, bufnr)
   -- local parser = ts.get_parser(bufnr, "http")
   -- print("PARSER", parser)
   local query = [[
@@ -435,41 +461,39 @@ M.ts_get_headers = function (qnode, bufnr)
 
   local parsed_query = ts.parse_query(parser_name, query)
   -- print(vim.inspect(parsed_query))
-  local start_row, _, end_row, _ = qnode:range()
-  print("start row", start_row, "end row", end_row)
+  -- local start_row, _, end_row, _ = qnode:range()
+  -- print("start row", start_row, "end row", end_row)
 
   local headers = {}
   for _id, headernode, _metadata in parsed_query:iter_captures(qnode, bufnr) do
-      -- local name = parsed_query.captures[id] -- name of the capture in the query
-      -- M.ts_build_request_from_node(tsnode, bufnr)
-      print_node("header node", headernode)
-      -- Returns a table of the nodes corresponding to the {name} field.
+    -- local name = parsed_query.captures[id] -- name of the capture in the query
+    -- M.ts_build_request_from_node(tsnode, bufnr)
+    -- print_node("header node", headernode)
+    -- Returns a table of the nodes corresponding to the {name} field.
 
-      local hnamenode = headernode:field("name")[1]
-      local hname = vim.treesitter.query.get_node_text(hnamenode, bufnr)
-      print("inspect hname", vim.inspect(hname))
-      local valuenode = headernode:field("value")[1]
-      local value = vim.treesitter.query.get_node_text(valuenode, bufnr)
-      print("Header name: ", hname, " = ", value)
-      -- TODO splice value variables !
-      headers[hname] = value
+    local hnamenode = headernode:field("name")[1]
+    local hname = vim.treesitter.query.get_node_text(hnamenode, bufnr)
+    local valuenode = headernode:field("value")[1]
+    local value = vim.treesitter.query.get_node_text(valuenode, bufnr)
+    -- TODO splice value variables !
+    headers[hname] = value
   end
   return headers
 end
 
-M.ts_get_requests = function (bufnr)
+M.buf_get_requests = function(bufnr)
   bufnr = bufnr or 0
 
   print("GET REQUESTS for buffer ", bufnr)
-  local parser = ts.get_parser(bufnr, "http")
+  -- local parser = ts.get_parser(bufnr, "http")
   -- print("PARSER", parser)
   local query = [[
       (query) @queries
   ]]
   -- parse returns a list of ts trees
   -- root is a node
-  local root = parser:parse()[1]:root()
-  local start_row, _, end_row, _ = root:range()
+  -- local root = parser:parse()[1]:root()
+  -- local start_row, _, end_row, _ = root:range()
 
   -- local start_node = root
   local start_node = ts_utils.get_node_at_cursor()
@@ -477,34 +501,39 @@ M.ts_get_requests = function (bufnr)
   -- print("sexpr: " .. start_node:sexpr())
   local parsed_query = ts.parse_query(parser_name, query)
   -- print(vim.inspect(parsed_query))
-  print("start row", start_row, "end row", end_row)
-  print_node("root", root)
+  -- print("start row", start_row, "end row", end_row)
+  -- print_node("root", root)
   local requests = {}
   -- , start_row, end_row
   for _id, tsnode, _metadata in parsed_query:iter_captures(start_node, bufnr) do
-      -- local name = parsed_query.captures[id] -- name of the capture in the query
+    -- local name = parsed_query.captures[id] -- name of the capture in the query
 
-      requests[#requests] = M.ts_build_request_from_node(tsnode, bufnr)
+    requests[#requests] = M.ts_build_request_from_node(tsnode, bufnr)
   end
 
   return requests
 end
 
 M.get_current_request = function()
+  return M.buf_get_current_request()
+end
+
+M.buf_get_current_request = function(bufnr)
+  log.debug("Getting current request")
+
   -- old implementation
   -- return M.buf_get_request(vim.api.nvim_win_get_buf(0), vim.fn.getcurpos())
-  local query_node = M.ts_get_current_request()
-  assert(query_node:type() == "query")
+  local query_node = M.buf_get_request_at_node(bufnr, ts_utils.get_node_at_cursor())
   local result = M.ts_build_request_from_node(query_node, 0)
   M.print_request(result)
   return true, result
 end
 
-M.ts_get_current_request = function()
+M.buf_get_request_at_node = function(_bufnr, start_node)
   local parser = ts.get_parser(0, "http")
   local root = parser:parse()[1]:root()
-  local start_node = ts_utils.get_node_at_cursor()
-  print("start node", start_node:type())
+  -- local start_node = ts_utils.get_node_at_cursor()
+  -- print("start node type", start_node:type())
   local node = start_node
   while node:type() ~= "query" and node ~= root do
     -- print("node before", node:type())
@@ -513,84 +542,21 @@ M.ts_get_current_request = function()
     -- node = ts_utils.get_previous_node(node, true, true)
     -- print("node after", node:type())
   end
-  print("out of loop node", node:type())
+  -- print("out of loop node", node:type())
   return node
 end
 
 -- buf_get_request returns a table with all the request settings
 -- @param bufnr (number|nil) the buffer number
--- @param curpos the cursor position
+-- @param pos (optional) the cursor position, by default the cursor position
 -- @return (boolean, request or string)
-M.buf_get_request = function(bufnr, curpos)
-  curpos = curpos or vim.fn.getcurpos()
+M.buf_get_request_at_pos = function(bufnr, pos)
+  pos = pos or vim.fn.getcurpos()
   bufnr = bufnr or vim.api.nvim_win_get_buf(0)
+  --
+  local node = M.get_node_at_pos(bufnr, pos[1] - 1, pos[2], { ignore_injections = false }):type()
+  return M.buf_get_request(bufnr, node)
 
-  error("SHOULD NOT BE USED ANYMORE")
-
-  -- todo load from file and merge with session variable
-  local vars = utils.read_variables()
-
-  -- TODO use M.ts_get_requests with a cursor pos ?
-  local start_line = start_request(bufnr, curpos[2])
-
-  if start_line == 0 then
-    return false, "No request found"
-  end
-  local end_line = end_request(bufnr, start_line)
-
-  local parsed_url = parse_url(vim.fn.getline(start_line), vars)
-
-  local headers, headers_end = get_headers(bufnr, start_line, end_line)
-
-  local curl_args, body_start = get_curl_args(bufnr, headers_end, end_line)
-
-  if headers["host"] ~= nil then
-    headers["host"] = headers["host"]:gsub("%s+", "")
-    headers["host"] = string.gsub(headers["host"], "%s+", "")
-    parsed_url.url = headers["host"] .. parsed_url.url
-    headers["host"] = nil
-  end
-
-  local content_type = ""
-
-  for key, val in pairs(headers) do
-    if string.lower(key) == "content-type" then
-      content_type = val
-      break
-    end
-  end
-
-
-  local body = get_body(
-    bufnr,
-    vars,
-    body_start,
-    end_line,
-    content_type:find("application/[^ ]*json")
-  )
-
-  local script_str = get_response_script(bufnr, headers_end, end_line)
-
-
-  if config.get("jump_to_request") then
-    utils.move_cursor(bufnr, start_line)
-  else
-    utils.move_cursor(bufnr, curpos[2], curpos[3])
-  end
-
-  return true,
-      {
-        method = parsed_url.method,
-        url = parsed_url.url,
-        http_version = parsed_url.http_version,
-        headers = headers,
-        raw = curl_args,
-        body = body,
-        bufnr = bufnr,
-        start_line = start_line,
-        end_line = end_line,
-        script_str = script_str
-      }
 end
 
 -- to remove
@@ -599,23 +565,43 @@ M.print_request = function(req)
 end
 
 -- converts request into string, helpful for debug
-M.stringify_request = function(req)
+-- full_body boolean
+M.stringify_request = function(req, opts)
+  opts = vim.tbl_deep_extend(
+    "force", -- use value from rightmost map
+    { full_body = false, -- TODO pass a function instead
+      headers = true
+    }, -- defaults
+    opts or {}
+  )
   local str = [[
-    url: ]] .. req.url .. [[\n
+    url   : ]] .. req.url .. [[\n
     method: ]] .. req.method .. [[\n
-    start_line: ]] .. tostring(req.start_line) .. [[\n
-    end_line: ]] .. tostring(req.end_line) .. [[\n
-  ]]
+    range : ]] .. tostring(req.start_line) .. [[ -> ]] .. tostring(req.end_line) .. [[\n
+    ]]
+
   if req.http_version then
-    str = str.."\nhttp_version: ".. req.http_version .. "\n"
+    str = str .. "\nhttp_version: " .. req.http_version .. "\n"
   end
 
-  if req.body then
-    str = str.."body: "..req.body.."\n"
+  if opts.headers then
+    -- str = str.."body: "..req.body.."\n"
+    for name, value in pairs(req.headers) do
+      str = str .. "header '" .. name .. "'=" .. value .. "\n"
+    end
+  end
+
+  -- opts.full_body
+  if true then
+    if req.body then
+      local res = req.body
+      -- table.concat(res, "\n")
+      str = str .. "body: " .. res .. "\n"
+    end
   end
 
   -- here we should just display the beginning of the request
-  print(str)
+  return (str)
 end
 
 local select_ns = vim.api.nvim_create_namespace("rest-nvim")

--- a/lua/rest-nvim/session/init.lua
+++ b/lua/rest-nvim/session/init.lua
@@ -1,11 +1,12 @@
 local config = require("rest-nvim.config")
+local utils = require("rest-nvim.utils")
 local M = {}
 
 M.set_env = function(key, value)
   if type(value) ~= "string" then
     print("Key ", key, " is not a string !")
   end
-  local variables = M.get_env_variables()
+  local variables = utils.get_env_variables()
   variables[key] = value
   -- let's not update the file for now
   M.write_env_file(variables)
@@ -24,14 +25,14 @@ M.write_env_file = function(variables)
 
   -- If there's an env file in the current working dir
   for _, env_file_path in ipairs(env_file_paths) do
-    if M.file_exists(env_file_path) then
+    if utils.file_exists(env_file_path) then
       local file = io.open(env_file_path, "w+")
       if file ~= nil then
         if string.match(env_file_path, "(.-)%.json$") then
           file:write(vim.fn.json_encode(variables))
         else
           for key, value in pairs(variables) do
-            print("SERIALIZE key", key, value)
+            -- print("SERIALIZE key", key, value)
             file:write(key .. "=" .. tostring(value) .. "\n")
           end
         end

--- a/lua/rest-nvim/session/init.lua
+++ b/lua/rest-nvim/session/init.lua
@@ -1,0 +1,44 @@
+local config = require("rest-nvim.config")
+local M = {}
+
+M.set_env = function(key, value)
+  if type(value) ~= "string" then
+    print("Key ", key, " is not a string !")
+  end
+  local variables = M.get_env_variables()
+  variables[key] = value
+  -- let's not update the file for now
+  M.write_env_file(variables)
+end
+
+M.write_env_file = function(variables)
+  local env_file = "/" .. (config.get("env_file") or ".env")
+
+  -- Directories to search for env files
+  local env_file_paths = {
+    -- current working directory
+    vim.fn.getcwd() .. env_file,
+    -- directory of the currently opened file
+    vim.fn.expand("%:p:h") .. env_file,
+  }
+
+  -- If there's an env file in the current working dir
+  for _, env_file_path in ipairs(env_file_paths) do
+    if M.file_exists(env_file_path) then
+      local file = io.open(env_file_path, "w+")
+      if file ~= nil then
+        if string.match(env_file_path, "(.-)%.json$") then
+          file:write(vim.fn.json_encode(variables))
+        else
+          for key, value in pairs(variables) do
+            print("SERIALIZE key", key, value)
+            file:write(key .. "=" .. tostring(value) .. "\n")
+          end
+        end
+        file:close()
+      end
+    end
+  end
+end
+
+return M

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -113,6 +113,7 @@ M.get_file_variables = function()
   end
   return variables
 end
+
 -- Gets the variables from the currently selected env_file
 M.get_env_variables = function()
   local variables = {}

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -27,6 +27,7 @@ end
 M.set_env = function(key, value)
   local variables = M.get_env_variables()
   variables[key] = value
+  -- let's not update the file for now
   M.write_env_file(variables)
 end
 
@@ -50,7 +51,8 @@ M.write_env_file = function(variables)
           file:write(vim.fn.json_encode(variables))
         else
           for key, value in pairs(variables) do
-            file:write(key .. "=" .. value .. "\n")
+            print("SERIALIZE ", value)
+            file:write(key .. "=" .. tostring(value) .. "\n")
           end
         end
         file:close()
@@ -142,7 +144,7 @@ M.get_env_variables = function()
 end
 
 -- get_variables Reads the environment variables found in the env_file option
--- (defualt: .env) specified in configuration or from the files being read
+-- (default: .env) specified in configuration or from the files being read
 -- with variables beginning with @ and returns a table with the variables
 M.get_variables = function()
   local variables = {}

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -24,42 +24,46 @@ M.move_cursor = function(bufnr, line, column)
   end)
 end
 
-M.set_env = function(key, value)
-  local variables = M.get_env_variables()
-  variables[key] = value
-  -- let's not update the file for now
-  M.write_env_file(variables)
-end
+-- MOVED TO  session/init.lua
+-- M.set_env = function(key, value)
+--   if type(value) ~= "string" then
+--     print("Key ", key, " is not a string !")
+--   end
+--   local variables = M.get_env_variables()
+--   variables[key] = value
+--   -- let's not update the file for now
+--   M.write_env_file(variables)
+-- end
 
-M.write_env_file = function(variables)
-  local env_file = "/" .. (config.get("env_file") or ".env")
+-- M.write_env_file = function(variables)
+--   local env_file = "/" .. (config.get("env_file") or ".env")
 
-  -- Directories to search for env files
-  local env_file_paths = {
-    -- current working directory
-    vim.fn.getcwd() .. env_file,
-    -- directory of the currently opened file
-    vim.fn.expand("%:p:h") .. env_file,
-  }
+--   -- Directories to search for env files
+--   local env_file_paths = {
+--     -- current working directory
+--     vim.fn.getcwd() .. env_file,
+--     -- directory of the currently opened file
+--     vim.fn.expand("%:p:h") .. env_file,
+--   }
 
-  -- If there's an env file in the current working dir
-  for _, env_file_path in ipairs(env_file_paths) do
-    if M.file_exists(env_file_path) then
-      local file = io.open(env_file_path, "w+")
-      if file ~= nil then
-        if string.match(env_file_path, "(.-)%.json$") then
-          file:write(vim.fn.json_encode(variables))
-        else
-          for key, value in pairs(variables) do
-            print("SERIALIZE ", value)
-            file:write(key .. "=" .. tostring(value) .. "\n")
-          end
-        end
-        file:close()
-      end
-    end
-  end
-end
+--   -- If there's an env file in the current working dir
+--   for _, env_file_path in ipairs(env_file_paths) do
+--     if M.file_exists(env_file_path) then
+--       local file = io.open(env_file_path, "w+")
+--       if file ~= nil then
+--         if string.match(env_file_path, "(.-)%.json$") then
+--           file:write(vim.fn.json_encode(variables))
+--         else
+--           for key, value in pairs(variables) do
+--             print("SERIALIZE key", key, value)
+--             file:write(key .. "=" .. tostring(value) .. "\n")
+--           end
+--         end
+--         file:close()
+--       end
+--     end
+--   end
+-- end
 
 M.uuid = function()
   local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"

--- a/tests/get_with_host.http
+++ b/tests/get_with_host.http
@@ -1,7 +1,6 @@
 ###
 
-GET /api/users?page=5
-Host: https://reqres.in
+GET https://reqres.in/api/users?page=5
 
 ###
 


### PR DESCRIPTION
trying to use treesitter nodes to identify the requests, method etc instead of relying on weak heuristics.

The issue I have at the moment is the root node appears as a "document" https://github.com/rest-nvim/tree-sitter-http/blob/2c6c44574031263326cb1e51658bbc0c084326e7/grammar.js#L15 but I can't find it anywhere in the treesitter playground

TODO:
- [ ] GET remove or ditch support for this syntax ?
```
/api/users?page=5 HTTP/1.1
Host: reqres.in:443
```
- [ ] support of curl_raw_args ?
- [ ] parse_url had `if config.get("encode_url") then  target_url = utils.encode_url(target_url)  end`, do we still need this ?
- [ ] check one can set http_version as in older version
- [ ] remove regex to capture the "script" part and instead retreive the content of the "internal_payload" node (problem is that currently the "internal_payload" node is full of errors)
- [x] support external body
- [ ] support embedded body

we already have variables
- [x] should be able to list requests in a file