### PR TITLE
fix: body should be present only in supported methods

### DIFF
--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -52,7 +52,7 @@ local function get_body(bufnr, start_line, stop_line, has_json)
     end
     lines = utils.read_file(importfile)
   else
-    lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, stop_line, false)
+    lines = vim.api.nvim_buf_get_lines(bufnr, start_line, stop_line, false)
   end
 
   local body = ""
@@ -291,6 +291,8 @@ M.get_current_request = function()
   return M.buf_get_request(vim.api.nvim_win_get_buf(0), vim.fn.getcurpos())
 end
 
+local methods_with_body = {"POST", "PUT", "PATCH", "DELETE"}
+
 -- buf_get_request returns a table with all the request settings
 -- @param bufnr (number|nil) the buffer number
 -- @param curpos the cursor position
@@ -328,12 +330,15 @@ M.buf_get_request = function(bufnr, curpos)
     end
   end
 
-  local body = get_body(
-    bufnr,
-    body_start,
-    end_line,
-    content_type:find("application/[^ ]*json")
-  )
+  local body;
+  if utils.has_value(methods_with_body, parsed_url.method) then
+    body = get_body(
+      bufnr,
+      body_start,
+      end_line,
+      content_type:find("application/[^ ]*json")
+    )
+  end
 
   local script_str = get_response_script(bufnr, headers_end, end_line)
 


### PR DESCRIPTION
Added condition on whether or not to include `--data-raw` parameter to the command. Only `POST`, `PUT`, `PATCH`, and `DELETE` should contain such parameters. 

## Cases:
### GET request with headers:
![20230114_15h37m35s_grim](https://user-images.githubusercontent.com/67589938/212477300-f29eefa8-52e0-42c7-916d-2f40475c8d86.png)
**CURRENT**
Result: 
`curl -sSL --compressed -X 'GET' -H 'Authorization: Bearer Test.Token' --data-raw 'authorization: Bearer Test.Token' 'https://test.com/auth/token/list'`
**EXPECTED**
Result: 
`curl -sSL --compressed -X 'GET' -H 'Authorization: Bearer Test.Token' 'https://test.com/auth/token/list'`

This one is critical since requests to the google cloud APIs, for instance, will reject such `GET` request.
![20230114_15h49m26s_grim](https://user-images.githubusercontent.com/67589938/212477828-064a3fb7-dd15-45fa-a8b2-e7066a1f910d.png)

[HTTP Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods)

### POST request without a body
![20230114_15h43m57s_grim](https://user-images.githubusercontent.com/67589938/212477589-c7c5ad2f-d46a-4e1c-a19e-2bbe8f2d6cec.png)
**CURRENT**
Result: 
`curl -sSL --compressed -X 'POST' -H 'Authorization: Bearer Test.Token' --data-raw 'authorization: Bearer Test.Token' 'https://test.com/auth/token/list'`
**EXPECTED**
Result: 
`curl -sSL --compressed -X 'POST' -H 'Authorization: Bearer Test.Token' --data-raw '' 'https://test.com/auth/token/list'`

Since the `vim.api.nvim_buf_get_lines` function accepts a zero-based index, and we want to ignore the line between headers and body, decreasing the value by 1 is incorrect.