### PR TITLE
ci: add tag release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Luarocks release
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  luarocks-release:
+    runs-on: ubuntu-latest
+    name: Luarocks upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Luarocks Upload
+        uses: mrcjkb/luarocks-tag-release@master
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}


### PR DESCRIPTION
publish rest.nvim automatically on luarocks upon new tag https://github.com/mrcjkb/luarocks-tag-release

one would need to add a LUAROCKS_API_KEY to the repo secrets, I dont have the rights but @NTBBloodbath can. I can give you such a key via mail if you want.