### PR TITLE
fix: include documentation on rockspec

### DIFF
--- a/rest.nvim-scm-1.rockspec
+++ b/rest.nvim-scm-1.rockspec
@@ -32,6 +32,7 @@ end
 build = {
    type = "builtin",
    copy_directories = {
+       'doc',
 	   'plugin'
    }
 }

--- a/rest.nvim-scm-3.rockspec
+++ b/rest.nvim-scm-3.rockspec
@@ -1,4 +1,4 @@
-local MAJOR, REV = "0.1", "-2"
+local MAJOR, REV = "scm", "-3"
 rockspec_format = "3.0"
 package = "rest.nvim"
 version = MAJOR .. REV


### PR DESCRIPTION
Fixes the missing documentation was missing when installing through luarocks.

Also, I noticed the following error when checking the `luarocks` build:

```
Error: Inconsistency between rockspec filename (rest.nvim-scm-1.rockspec) and its contents (rest.nvim-0.1-2.rockspec).
```

I changed both to `scm-3` but maybe another major is better.