### PR TITLE
Exclude encoding `@` to support `user:pass@host` authentication

### DIFF
--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -365,8 +365,8 @@ M.encode_url = function(url)
   end
 
   url = url:gsub("\n", "\r\n")
-  -- Encode characters but exclude `.`, `_`, `-`, `:`, `/`, `?`, `&`, `=`, `~`
-  url = string.gsub(url, "([^%w _ %- . : / ? & = ~])", M.char_to_hex)
+  -- Encode characters but exclude `.`, `_`, `-`, `:`, `/`, `?`, `&`, `=`, `~`, `@`
+  url = string.gsub(url, "([^%w _ %- . : / ? & = ~ @])", M.char_to_hex)
   url = url:gsub(" ", "+")
   return url
 end


### PR DESCRIPTION
fixes https://github.com/rest-nvim/rest.nvim/issues/89

I see there's https://github.com/rest-nvim/rest.nvim/pull/115, but this is a one-character change, would you like to consider it? Thanks anyways