### PR TITLE
dont display binary outputs in answer

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,4 +11,4 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: |
-        nix develop . -c make test
+        nix develop .#ci -c make test

--- a/flake.nix
+++ b/flake.nix
@@ -13,41 +13,11 @@
 
         mkDevShell = luaVersion:
           let
-            # luaPkgs = pkgs."lua${luaVersion}".pkgs;
             luaEnv = pkgs."lua${luaVersion}".withPackages (lp: with lp; [
               busted
               luacheck
               luarocks
             ]);
-            neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
-              plugins = with pkgs.vimPlugins; [
-                { 
-                  plugin = packer-nvim;
-                  type = "lua";
-                  config = ''
-                    require('packer').init({
-                      luarocks = {
-                        python_cmd = 'python' -- Set the python command to use for running hererocks
-                      },
-                    })
-                    -- require my own manual config
-                    require('init-manual')
-                  '';
-                }
-                { plugin = (nvim-treesitter.withPlugins (
-                    plugins: with plugins; [
-                      tree-sitter-lua
-                      tree-sitter-http
-                      tree-sitter-json
-                    ]
-                  ));
-                }
-                { plugin = plenary-nvim; }
-              ];
-              customRC = "";
-	      wrapRc = false;
-            };
-            myNeovim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped neovimConfig;
           in
           pkgs.mkShell {
             name = "rest-nvim";
@@ -55,8 +25,6 @@
               pkgs.sumneko-lua-language-server
               luaEnv
               pkgs.stylua
-              myNeovim
-              # pkgs.neovim  # assume user has one already installed
             ];
 
             shellHook = let 
@@ -68,31 +36,45 @@
                         tree-sitter-json
                       ]
                     ))];
-                      # opt = map (x: x.plugin) pluginsPartitioned.right;
                 };
-              # };
               packDirArgs.myNeovimPackages = myVimPackage;
             in 
               ''
-                export DEBUG_PLENARY="debug"
-                cat <<-EOF > minimal.vim
-                  set rtp+=.
-                  set packpath^=${pkgs.vimUtils.packDir packDirArgs}
-                EOF
+              export DEBUG_PLENARY="debug"
+              cat <<-EOF > minimal.vim
+                set rtp+=.
+                set packpath^=${pkgs.vimUtils.packDir packDirArgs}
+              EOF
               '';
           };
 
       in
       {
 
-        # packages = {
-        #   default = self.packages.${system}.luarocks-51;
-        #   luarocks-51 = mkPackage "5_1";
-        #   luarocks-52 = mkPackage "5_2";
-        # };
-
         devShells = {
           default = self.devShells.${system}.luajit;
+          ci = let 
+            neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
+              plugins = with pkgs.vimPlugins; [
+                { plugin = (nvim-treesitter.withPlugins (
+                    plugins: with plugins; [
+                      tree-sitter-lua
+                      tree-sitter-http
+                      tree-sitter-json
+                    ]
+                  ));
+                }
+                { plugin = plenary-nvim; }
+              ];
+              customRC = "";
+              wrapRc = false;
+            };
+            myNeovim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped neovimConfig;
+            in 
+              (mkDevShell "jit").overrideAttrs(oa: {
+                buildInputs = oa.buildInputs ++ [ myNeovim ];
+              });
+
           luajit = mkDevShell "jit";
           lua-51 = mkDevShell "5_1";
           lua-52 = mkDevShell "5_2";

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -63,7 +63,7 @@ local function create_callback(method, url, script_str)
     -- get content type
     for _, header in ipairs(res.headers) do
       if string.lower(header):find("^content%-type") then
-        content_type = header:match("application/(%l+)") or header:match("text/(%l+)")
+        content_type = header:match("application/([-a-z]+)") or header:match("text/(%l+)")
         break
       end
     end
@@ -150,9 +150,15 @@ local function create_callback(method, url, script_str)
     end
 
     -- append response container
-    res.body = "#+RESPONSE\n" .. res.body .. "\n#+END"
+    local buf_content = "#+RESPONSE\n"
+    if utils.is_binary_content_type(content_type) then
+      buf_content = buf_content .. "Binary answer"
+    else
+      buf_content = buf_content .. res.body
+    end
+    buf_content = buf_content .. "\n#+END"
 
-    local lines = utils.split(res.body, "\n")
+    local lines = utils.split(buf_content, "\n")
     local line_count = vim.api.nvim_buf_line_count(res_bufnr) - 1
     vim.api.nvim_buf_set_lines(res_bufnr, line_count, line_count + #lines, false, lines)
 

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -21,7 +21,7 @@ local function get_importfile_name(bufnr, start_line, stop_line)
     local fileimport_spliced
     fileimport_line = vim.api.nvim_buf_get_lines(bufnr, import_line - 1, import_line, false)
     fileimport_string =
-    string.gsub(fileimport_line[1], "<", "", 1):gsub("^%s+", ""):gsub("%s+$", "")
+      string.gsub(fileimport_line[1], "<", "", 1):gsub("^%s+", ""):gsub("%s+$", "")
     fileimport_spliced = utils.replace_vars(fileimport_string)
     if path:new(fileimport_spliced):is_absolute() then
       return fileimport_spliced
@@ -88,7 +88,6 @@ local function get_body(bufnr, start_line, stop_line, has_json)
       return vim.fn.json_encode(json_body)
     end
   end
-
 
   return body
 end

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -5,6 +5,14 @@ math.randomseed(os.time())
 
 local M = {}
 
+M.binary_content_types = {
+  "octet-stream",
+}
+
+M.is_binary_content_type = function(content_type)
+  return vim.tbl_contains(M.binary_content_types, content_type)
+end
+
 -- move_cursor moves the cursor to the desired position in the provided buffer
 -- @param bufnr Buffer number, a.k.a id
 -- @param line the desired line


### PR DESCRIPTION
I was testing an API that returned a zip file and it was getting out of
hand so I added an is_binary_content_type to control whether to display
the content type.
Ideally I would have liked the display to be a default postprocess step so
that it gets more generic and let the user more control but this needs
deeper refactoring.