### PR TITLE
feat: add config.show_curl_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ use {
       result = {
         -- toggle showing URL, HTTP info, headers at top the of result window
         show_url = true,
+        -- show the generated curl command in case you want to launch
+        -- the same request via the terminal (can be verbose)
+        show_curl_command = false,
         show_http_info = true,
         show_headers = true,
         -- executables or functions for formatting response body [optional]

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -10,6 +10,7 @@ local config = {
     timeout = 150,
   },
   result = {
+    show_curl_command = true,
     show_url = true,
     show_http_info = true,
     show_headers = true,


### PR DESCRIPTION
This is gated behind a flag at false by default because it can be quite verbose.
Sometimes we may want to rerun the command run by rest.nvim with additional parameters, for instance to save the output in a specific file.