### PR TITLE
feat: introduce stringify_request

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -55,11 +55,19 @@ rest.run_file = function(filename, opts)
   return true
 end
 
+
+-- run will retrieve the required request information from the current buffer
+-- and then execute curl
+-- @param req table see validate_request to check the expected format
+-- @param opts table
+--           1. keep_going boolean keep running even when last request failed
 rest.run_request = function(req, opts)
   local result = req
   opts = vim.tbl_deep_extend(
     "force", -- use value from rightmost map
-    { verbose = false }, -- defaults
+    { verbose = false,
+      highlight = false
+    }, -- defaults
     opts or {}
   )
 
@@ -83,7 +91,7 @@ rest.run_request = function(req, opts)
     LastOpts = Opts
   end
 
-  if config.get("highlight").enabled then
+  if opts.highlight then
     request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -17,6 +17,8 @@ end
 rest.run = function(verbose)
   local ok, result = request.get_current_request()
   if not ok then
+    log.error("Failed to run the http request:")
+    log.error(result)
     vim.api.nvim_err_writeln("[rest.nvim] Failed to get the current HTTP request: " .. result)
     return
   end

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -359,13 +359,44 @@ M.buf_get_request = function(bufnr, curpos)
 end
 
 M.print_request = function(req)
+  print(M.stringify_request(req))
+end
+
+-- converts request into string, helpful for debug
+-- full_body boolean
+M.stringify_request = function(req, opts)
+  opts = vim.tbl_deep_extend(
+    "force", -- use value from rightmost map
+    { full_body = false,
+      headers = true
+    }, -- defaults
+    opts or {}
+  )
   local str = [[
-    version: ]] .. req.url .. [[\n
+    url   : ]] .. req.url .. [[\n
     method: ]] .. req.method .. [[\n
-    start_line: ]] .. tostring(req.start_line) .. [[\n
-    end_line: ]] .. tostring(req.end_line) .. [[\n
-  ]]
-  print(str)
+    range : ]] .. tostring(req.start_line) .. [[ -> ]] .. tostring(req.end_line) .. [[\n
+    ]]
+
+  if req.http_version then
+    str = str .. "\nhttp_version: " .. req.http_version .. "\n"
+  end
+
+  if opts.headers then
+    for name, value in pairs(req.headers) do
+      str = str .. "header '" .. name .. "'=" .. value .. "\n"
+    end
+  end
+
+  if opts.full_body then
+    if req.body then
+      local res = req.body
+      str = str .. "body: " .. res .. "\n"
+    end
+  end
+
+  -- here we should just display the beginning of the request
+  return (str)
 end
 
 local select_ns = vim.api.nvim_create_namespace("rest-nvim")


### PR DESCRIPTION
allows to dump request to logs as well

allows to dump request to logs as well. The caller can control what is dumped: I found this quite useful to debug the treesitter branch