### PR TITLE
add callbacks on start/stop request

### DIFF
--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -21,6 +21,7 @@ CONTENTS                                                   *rest-nvim-contents*
         3. Import body from external file......|rest-nvim-usage-external-files|
         4. Environment Variables........|rest-nvim-usage-environment-variables|
         5. Dynamic Variables................|rest-nvim-usage-dynamic-variables|
+        6. Callbacks................................|rest-nvim-usage-callbacks|
     5. Known issues..........................................|rest-nvim-issues|
     6. License..............................................|rest-nvim-license|
     7. Contributing....................................|rest-nvim-contributing|
@@ -219,6 +220,22 @@ You can extend or overwrite built-in dynamic variables, with the config key
 `    end,`
 `  },`
 `})`
+
+===============================================================================
+CALLBACKS                                             *rest-nvim-usage-callbacks*
+
+rest.nvim fires different events upon requests:
+   - a User RestStartRequest event when launching the request
+   - a User RestStopRequest event when the requests finishes or errors out
+
+vim.api.nvim_create_autocmd("User", {
+pattern = "RestStartRequest",
+once = true,
+  callback = function(opts)
+     print("IT STARTED")
+     vim.pretty_print(opts)
+  end,
+})
 
 
 ===============================================================================

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -95,7 +95,20 @@ rest.run_request = function(req, opts)
     request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 
+  local request_id = vim.loop.now()
+  local data = {
+        requestId = request_id,
+        request = req
+      }
+
+  vim.api.nvim_exec_autocmds("User", {
+      pattern = "RestStartRequest",
+      modeline = false,
+      data = data
+    })
   local success_req, req_err = pcall(curl.curl_cmd, Opts)
+  vim.api.nvim_exec_autocmds("User", { pattern = "RestStopRequest", modeline = false,
+      data = vim.tbl_extend("keep", { status = success_req, message = req_err }, data)  })
 
   if not success_req then
     vim.api.nvim_err_writeln(


### PR DESCRIPTION
This is a quick & dirty implementation of https://github.com/rest-nvim/rest.nvim/pull/214, e.g., rest-nvim throws events when 
- launching a request
- finishing a request

This is what I intented to test it with
```
local start_time = 0

local on_start_request =  function (req)
  -- vim.loop.gettimeofday()
  -- vim.fn.reltime()
 start_time = vim.loop.now()
 print("starting request")
end

local on_stop_request =  function  (...)
 print("finished request")
 -- TODO displayu time taken
end

vim.api.nvim_create_autocmd("User", {
pattern = "RestStartRequest",
once = true,
  callback = function()
    print("IT STARTED")
  end,
})
```

