### PR TITLE
dont inline file

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ request method (e.g. `GET`) and run `rest.nvim`.
 
 ---
 
+### Debug
+
+
+Run `export DEBUG_PLENARY="debug"` before starting nvim. Logs will appear most
+likely in ~/.cache/nvim/rest.nvim.log
+
+
 ## Contribute
 
 1. Fork it (https://github.com/rest-nvim/rest.nvim/fork)

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -40,9 +40,9 @@ M.get_or_create_buf = function()
   local existing_bufnr = vim.fn.bufnr(tmp_name)
   if existing_bufnr ~= -1 then
     -- Set modifiable
-    vim.api.nvim_set_option_value(existing_bufnr, "modifiable", true)
+    vim.api.nvim_set_option_value("modifiable", true, { buf = existing_bufnr})
     -- Prevent modified flag
-    vim.api.nvim_set_option_value(existing_bufnr, "buftype", "nofile")
+    vim.api.nvim_set_option_value("buftype", "nofile", { buf = existing_bufnr})
     -- Delete buffer content
     vim.api.nvim_buf_set_lines(
       existing_bufnr,
@@ -59,7 +59,7 @@ M.get_or_create_buf = function()
   end
 
   -- Create new buffer
-  local new_bufnr = vim.api.nvim_create_buf(false, "nomodeline")
+  local new_bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_name(new_bufnr, tmp_name)
   vim.api.nvim_set_option_value("ft", "httpResult", { buf = new_bufnr })
   vim.api.nvim_set_option_value("buftype", "nofile", { buf = new_bufnr })

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -102,7 +102,7 @@ local function create_callback(curl_cmd, method, url, script_str)
 
     -- This can be quite verbose so let user control it
     if config.get("result").show_curl_command then
-      vim.api.nvim_buf_set_lines(res_bufnr, 0, 0, false, { "Command :" .. curl_cmd })
+      vim.api.nvim_buf_set_lines(res_bufnr, 0, 0, false, { "Command: " .. curl_cmd })
     end
 
     if config.get("result").show_url then

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -397,8 +397,7 @@ M.highlight = function(bufnr, start_line, end_line)
     higroup,
     { start_line - 1, 0 },
     { end_line - 1, end_column },
-    "c",
-    false
+    { regtype = "c"; inclusive = false }
   )
 
   vim.defer_fn(function()


### PR DESCRIPTION
- doc: mention debug instructions
- feat: make it possible to not inline external file

if you reference a file via <@ file instead of < file the filename will be passed as is to curl, thus making the curl command in preview a ton shorter. 
