### PR TITLE
separate parsing from running steps

### DIFF
--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -31,7 +31,6 @@ local function format_curl_cmd(res)
   return cmd
 end
 
-
 -- get_or_create_buf checks if there is already a buffer with the rest run results
 -- and if the buffer does not exists, then create a new one
 M.get_or_create_buf = function()
@@ -230,7 +229,7 @@ end
 M.curl_cmd = function(opts)
   -- plenary's curl module is strange in the sense that with "dry_run" it returns the command
   -- otherwise it starts the request :/
-  local dry_run_opts = vim.tbl_extend("force", opts, { dry_run = true } )
+  local dry_run_opts = vim.tbl_extend("force", opts, { dry_run = true })
   local res = curl[opts.method](dry_run_opts)
   local curl_cmd = format_curl_cmd(res)
 
@@ -242,7 +241,8 @@ M.curl_cmd = function(opts)
     vim.api.nvim_echo({ { "[rest.nvim] Request preview:\n", "Comment" }, { curl_cmd } }, false, {})
     return
   else
-    opts.callback = vim.schedule_wrap(create_callback(curl_cmd, opts.method, opts.url, opts.script_str))
+    opts.callback =
+      vim.schedule_wrap(create_callback(curl_cmd, opts.method, opts.url, opts.script_str))
     curl[opts.method](opts)
   end
 end

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -2,19 +2,20 @@ local backend = require("rest-nvim.request")
 local config = require("rest-nvim.config")
 local curl = require("rest-nvim.curl")
 local log = require("plenary.log").new({ plugin = "rest.nvim" })
+local utils = require("rest-nvim.utils")
+local path = require("plenary.path")
 
 local rest = {}
 local Opts = {}
 local defaultRequestOpts = {
-    verbose = false,
-    highlight = false,
-    engine = 'classic'
-  }
+  verbose = false,
+  highlight = false,
+}
 
 local LastOpts = {}
+
 rest.setup = function(user_configs)
   config.set(user_configs or {})
-
 end
 
 -- run will retrieve the required request information from the current buffer
@@ -37,7 +38,7 @@ end
 -- @param string filename to load
 -- @param opts table
 --           1. keep_going boolean keep running even when last request failed
---           2. verbose boolean 
+--           2. verbose boolean
 rest.run_file = function(filename, opts)
   log.info("Running file :" .. filename)
   opts = vim.tbl_deep_extend(
@@ -54,14 +55,87 @@ rest.run_file = function(filename, opts)
 
   local requests = backend.buf_list_requests(new_buf)
   for _, req in pairs(requests) do
-    vim.pretty_print("Request:")
-    vim.pretty_print(req)
     rest.run_request(req, opts)
   end
 
   return true
 end
 
+-- replace variables in header values
+local function splice_headers(headers)
+  for name, value in pairs(headers) do
+    headers[name] = utils.replace_vars(value)
+  end
+  return headers
+end
+
+-- return the spliced/resolved filename
+-- @param string the filename w/o variables
+local function load_external_payload(fileimport_string)
+  local fileimport_spliced = utils.replace_vars(fileimport_string)
+  if path:new(fileimport_spliced):is_absolute() then
+    return fileimport_spliced
+  else
+    local file_dirname = vim.fn.expand("%:p:h")
+    local file_name = path:new(path:new(file_dirname), fileimport_spliced)
+    return file_name:absolute()
+  end
+end
+
+
+-- @param headers table  HTTP headers
+-- @param payload table of the form { external = bool, filename_tpl= path, body_tpl = string }
+--                 with body_tpl an array of lines
+local function splice_body(headers, payload)
+  local external_payload = payload.external
+  local lines -- array of strings
+  if external_payload then
+    local importfile = load_external_payload(payload.filename_tpl)
+    if not utils.file_exists(importfile) then
+      error("import file " .. importfile .. " not found")
+    end
+    -- TODO we dont necessarily want to load the file, it can be slow
+    -- https://github.com/rest-nvim/rest.nvim/issues/203
+    lines = utils.read_file(importfile)
+  else
+    lines = payload.body_tpl
+  end
+  local content_type = ""
+  for key, val in pairs(headers) do
+    if string.lower(key) == "content-type" then
+      content_type = val
+      break
+    end
+  end
+  local has_json = content_type:find("application/[^ ]*json")
+
+  local body = ""
+  local vars = utils.read_variables()
+  -- nvim_buf_get_lines is zero based and end-exclusive
+  -- but start_line and stop_line are one-based and inclusive
+  -- magically, this fits :-) start_line is the CRLF between header and body
+  -- which should not be included in the body, stop_line is the last line of the body
+  for _, line in ipairs(lines) do
+    body = body .. utils.replace_vars(line, vars)
+  end
+
+  local is_json, json_body = pcall(vim.json.decode, body)
+
+  if is_json and json_body then
+    if has_json then
+      -- convert entire json body to string.
+      return vim.fn.json_encode(json_body)
+    else
+      -- convert nested tables to string.
+      for key, val in pairs(json_body) do
+        if type(val) == "table" then
+          json_body[key] = vim.fn.json_encode(val)
+        end
+      end
+      return vim.fn.json_encode(json_body)
+    end
+  end
+end
 
 -- run will retrieve the required request information from the current buffer
 -- and then execute curl
@@ -69,7 +143,7 @@ end
 -- @param opts table
 --           1. keep_going boolean keep running even when last request failed
 rest.run_request = function(req, opts)
-  -- TODO rename result to req
+  -- TODO rename result to request
   local result = req
   opts = vim.tbl_deep_extend(
     "force", -- use value from rightmost map
@@ -77,15 +151,17 @@ rest.run_request = function(req, opts)
     opts or {}
   )
 
+  -- body =
+
   Opts = {
     method = result.method:lower(),
     url = result.url,
     -- plenary.curl can't set http protocol version
     -- http_version = result.http_version,
-    headers = result.headers,
+    headers = splice_headers(result.headers),
     raw = config.get("skip_ssl_verification") and vim.list_extend(result.raw, { "-k" })
       or result.raw,
-    body = result.body,
+    body = splice_body(result.headers, result.body),
     dry_run = opts.verbose,
     bufnr = result.bufnr,
     start_line = result.start_line,
@@ -103,18 +179,21 @@ rest.run_request = function(req, opts)
 
   local request_id = vim.loop.now()
   local data = {
-        requestId = request_id,
-        request = req
-      }
+    requestId = request_id,
+    request = req,
+  }
 
   vim.api.nvim_exec_autocmds("User", {
-      pattern = "RestStartRequest",
-      modeline = false,
-      data = data
-    })
+    pattern = "RestStartRequest",
+    modeline = false,
+    data = data,
+  })
   local success_req, req_err = pcall(curl.curl_cmd, Opts)
-  vim.api.nvim_exec_autocmds("User", { pattern = "RestStopRequest", modeline = false,
-      data = vim.tbl_extend("keep", { status = success_req, message = req_err }, data)  })
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "RestStopRequest",
+    modeline = false,
+    data = vim.tbl_extend("keep", { status = success_req, message = req_err }, data),
+  })
 
   if not success_req then
     vim.api.nvim_err_writeln(
@@ -148,10 +227,10 @@ end
 
 rest.request = backend
 
-rest.select_env = function(path)
+rest.select_env = function(env_file)
   if path ~= nil then
-    vim.validate({ path = { path, "string" } })
-    config.set({ env_file = path })
+    vim.validate({ env_file = { env_file, "string" } })
+    config.set({ env_file = env_file })
   else
     print("No path given")
   end

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -1,5 +1,4 @@
 local utils = require("rest-nvim.utils")
-local path = require("plenary.path")
 local log = require("plenary.log").new({ plugin = "rest.nvim" })
 local config = require("rest-nvim.config")
 
@@ -18,18 +17,10 @@ local function get_importfile_name(bufnr, start_line, stop_line)
   if import_line > 0 then
     local fileimport_string
     local fileimport_line
-    local fileimport_spliced
     fileimport_line = vim.api.nvim_buf_get_lines(bufnr, import_line - 1, import_line, false)
     fileimport_string =
       string.gsub(fileimport_line[1], "<", "", 1):gsub("^%s+", ""):gsub("%s+$", "")
-    fileimport_spliced = utils.replace_vars(fileimport_string)
-    if path:new(fileimport_spliced):is_absolute() then
-      return fileimport_spliced
-    else
-      local file_dirname = vim.fn.expand("%:p:h")
-      local file_name = path:new(path:new(file_dirname), fileimport_spliced)
-      return file_name:absolute()
-    end
+    return fileimport_string
   end
   return nil
 end
@@ -41,26 +32,22 @@ end
 -- @param bufnr Buffer number, a.k.a id
 -- @param start_line Line where body starts
 -- @param stop_line Line where body stops
--- @param has_json True if content-type is set to json
-local function get_body(bufnr, start_line, stop_line, has_json)
+-- @return table { external = bool; filename_tpl or body_tpl; }
+local function get_body(bufnr, start_line, stop_line)
   -- first check if the body should be imported from an external file
   local importfile = get_importfile_name(bufnr, start_line, stop_line)
-  local lines
+  local lines -- an array of strings
   if importfile ~= nil then
-    if not utils.file_exists(importfile) then
-      error("import file " .. importfile .. " not found")
-    end
-    lines = utils.read_file(importfile)
+    return { external = true, filename_tpl = importfile }
   else
-    lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, stop_line, false)
+    lines = vim.api.nvim_buf_get_lines(bufnr, start_line, stop_line, false)
   end
 
-  local body = ""
-  local vars = utils.read_variables()
   -- nvim_buf_get_lines is zero based and end-exclusive
   -- but start_line and stop_line are one-based and inclusive
   -- magically, this fits :-) start_line is the CRLF between header and body
   -- which should not be included in the body, stop_line is the last line of the body
+  local lines2 = {}
   for _, line in ipairs(lines) do
     -- stop if a script opening tag is found
     if line:find("{%%") then
@@ -68,28 +55,11 @@ local function get_body(bufnr, start_line, stop_line, has_json)
     end
     -- Ignore commented lines with and without indent
     if not utils.contains_comments(line) then
-      body = body .. utils.replace_vars(line, vars)
+      lines2[#lines2 + 1] = line
     end
   end
 
-  local is_json, json_body = pcall(vim.json.decode, body)
-
-  if is_json then
-    if has_json then
-      -- convert entire json body to string.
-      return vim.fn.json_encode(json_body)
-    else
-      -- convert nested tables to string.
-      for key, val in pairs(json_body) do
-        if type(val) == "table" then
-          json_body[key] = vim.fn.json_encode(val)
-        end
-      end
-      return vim.fn.json_encode(json_body)
-    end
-  end
-
-  return body
+  return { external = false, body_tpl = lines2 }
 end
 
 local function get_response_script(bufnr, start_line, stop_line)
@@ -161,7 +131,7 @@ local function get_headers(bufnr, start_line, end_line)
     local header_name, header_value = line_content:match("^(.-): ?(.*)$")
 
     if not utils.contains_comments(header_name) then
-      headers[header_name] = utils.replace_vars(header_value)
+      headers[header_name] = header_value
     end
     ::continue::
   end
@@ -240,8 +210,8 @@ local function end_request(bufnr, linenumber)
   end
   utils.move_cursor(bufnr, linenumber)
 
-  local next = vim.fn.search("^GET\\|^POST\\|^PUT\\|^PATCH\\|^DELETE\\|^###\\", "cn",
-    vim.fn.line("$"))
+  local next =
+    vim.fn.search("^GET\\|^POST\\|^PUT\\|^PATCH\\|^DELETE\\|^###\\", "cn", vim.fn.line("$"))
 
   -- restore cursor position
   utils.move_cursor(bufnr, oldlinenumber)
@@ -319,44 +289,32 @@ M.buf_get_request = function(bufnr, curpos)
     headers["host"] = nil
   end
 
-  local content_type = ""
-
-  for key, val in pairs(headers) do
-    if string.lower(key) == "content-type" then
-      content_type = val
-      break
-    end
-  end
-
-  local body = get_body(
-    bufnr,
-    body_start,
-    end_line,
-    content_type:find("application/[^ ]*json")
-  )
+  local body = get_body(bufnr, body_start, end_line)
 
   local script_str = get_response_script(bufnr, headers_end, end_line)
 
-
+  -- TODO this should just parse the request without modifying external state
+  -- eg move to run_request
   if config.get("jump_to_request") then
     utils.move_cursor(bufnr, start_line)
   else
     utils.move_cursor(bufnr, curpos[2], curpos[3])
   end
 
-  return true,
-      {
-        method = parsed_url.method,
-        url = parsed_url.url,
-        http_version = parsed_url.http_version,
-        headers = headers,
-        raw = curl_args,
-        body = body,
-        bufnr = bufnr,
-        start_line = start_line,
-        end_line = end_line,
-        script_str = script_str
-      }
+  local req = {
+      method = parsed_url.method,
+      url = parsed_url.url,
+      http_version = parsed_url.http_version,
+      headers = headers,
+      raw = curl_args,
+      body = body,
+      bufnr = bufnr,
+      start_line = start_line,
+      end_line = end_line,
+      script_str = script_str,
+    }
+
+  return true, req
 end
 
 M.print_request = function(req)
@@ -368,9 +326,7 @@ end
 M.stringify_request = function(req, opts)
   opts = vim.tbl_deep_extend(
     "force", -- use value from rightmost map
-    { full_body = false,
-      headers = true
-    }, -- defaults
+    { full_body = false, headers = true }, -- defaults
     opts or {}
   )
   local str = [[
@@ -397,7 +353,7 @@ M.stringify_request = function(req, opts)
   end
 
   -- here we should just display the beginning of the request
-  return (str)
+  return str
 end
 
 M.buf_list_requests = function(buf, _opts)
@@ -405,7 +361,7 @@ M.buf_list_requests = function(buf, _opts)
   local requests = {}
 
   -- reset cursor position
-  vim.fn.cursor({1, 1})
+  vim.fn.cursor({ 1, 1 })
   local curpos = vim.fn.getcurpos()
   log.debug("Listing requests for buf ", buf)
   while curpos[2] <= last_line do

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -177,6 +177,7 @@ local function get_curl_args(bufnr, headers_end, end_line)
   local curl_args = {}
   local body_start = end_line
 
+  log.debug("Getting curl args between lines", headers_end, " and ", end_line)
   for line_number = headers_end, end_line do
     local line_content = vim.fn.getbufline(bufnr, line_number)[1]
 
@@ -397,6 +398,27 @@ M.stringify_request = function(req, opts)
 
   -- here we should just display the beginning of the request
   return (str)
+end
+
+M.buf_list_requests = function(buf, _opts)
+  local last_line = vim.fn.line("$")
+  local requests = {}
+
+  -- reset cursor position
+  vim.fn.cursor({1, 1})
+  local curpos = vim.fn.getcurpos()
+  log.debug("Listing requests for buf ", buf)
+  while curpos[2] <= last_line do
+    local ok, req = M.buf_get_request(buf, curpos)
+    if ok then
+      curpos[2] = req.end_line + 1
+      requests[#requests + 1] = req
+    else
+      break
+    end
+  end
+  -- log.debug("found " , #requests , "requests")
+  return requests
 end
 
 local select_ns = vim.api.nvim_create_namespace("rest-nvim")


### PR DESCRIPTION
the treesitter backend is promising but it is too much work to reach feature parity with our current parser: 
https://github.com/rest-nvim/rest.nvim/pull/174

what I am proposing here is a first refactoring to delay variable splicing until last minute. 
It untangles parsing & running requests. Right now you need variables to exist when parsing which means you have to execute the request when parsing them else you get errors.
This PR replaces (aka "splices") the variables at the last minute so you can parse requests without executing them.
It allowed me to add a `buf_list_request` function in the current backend, which was not possible before, so now `run_file` is backend agnostic (it first lists requests and then run them).

In this PR, you can't change backend yet but in a future one, I will add a treesitter backend to parse request.
We will then be able to switch  (optional) to a treesitter backend even though it's not complete (One could even imagine a hurl backend) which will make working on it easier. 