### PR TITLE
Fix RestStopRequest event 

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -8,6 +8,7 @@ rest-nvim-license	rest-nvim.txt	/*rest-nvim-license*
 rest-nvim-quick-start	rest-nvim.txt	/*rest-nvim-quick-start*
 rest-nvim-response-script	rest-nvim.txt	/*rest-nvim-response-script*
 rest-nvim-usage	rest-nvim.txt	/*rest-nvim-usage*
+rest-nvim-usage-callbacks	rest-nvim.txt	/*rest-nvim-usage-callbacks*
 rest-nvim-usage-commands	rest-nvim.txt	/*rest-nvim-usage-commands*
 rest-nvim-usage-dynamic-variables	rest-nvim.txt	/*rest-nvim-usage-dynamic-variables*
 rest-nvim-usage-environment-variables	rest-nvim.txt	/*rest-nvim-usage-environment-variables*

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -31,6 +31,29 @@ local function format_curl_cmd(res)
   return cmd
 end
 
+local function send_curl_start_event(data)
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "RestStartRequest",
+    modeline = false,
+    data = data,
+  })
+end
+
+local function send_curl_stop_event(data)
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "RestStopRequest",
+    modeline = false,
+    data = data,
+  })
+end
+
+local function create_error_handler(opts)
+  return function(err)
+    send_curl_stop_event(vim.tbl_extend("keep", { err = err }, opts))
+    vim.notify(vim.inspect(err.message), vim.log.levels.ERROR)
+  end
+end
+
 -- get_or_create_buf checks if there is already a buffer with the rest run results
 -- and if the buffer does not exists, then create a new one
 M.get_or_create_buf = function()
@@ -64,12 +87,17 @@ M.get_or_create_buf = function()
   vim.api.nvim_set_option_value("ft", "httpResult", { buf = new_bufnr })
   vim.api.nvim_set_option_value("buftype", "nofile", { buf = new_bufnr })
 
-
   return new_bufnr
 end
 
-local function create_callback(curl_cmd, method, url, script_str)
+local function create_callback(curl_cmd, opts)
+  local method = opts.method
+  local url = opts.url
+  local script_str = opts.script_str
+
   return function(res)
+    send_curl_stop_event(vim.tbl_extend("keep", { res = res }, opts))
+
     if res.exit ~= 0 then
       log.error("[rest.nvim] " .. utils.curl_error(res.exit))
       return
@@ -234,16 +262,20 @@ M.curl_cmd = function(opts)
   local res = curl[opts.method](dry_run_opts)
   local curl_cmd = format_curl_cmd(res)
 
+  send_curl_start_event(opts)
+
   if opts.dry_run then
     if config.get("yank_dry_run") then
       vim.cmd("let @+=" .. string.format("%q", curl_cmd))
     end
 
     vim.api.nvim_echo({ { "[rest.nvim] Request preview:\n", "Comment" }, { curl_cmd } }, false, {})
+
+    send_curl_stop_event(opts)
     return
   else
-    opts.callback =
-      vim.schedule_wrap(create_callback(curl_cmd, opts.method, opts.url, opts.script_str))
+    opts.callback = vim.schedule_wrap(create_callback(curl_cmd, opts))
+    opts.on_error = vim.schedule_wrap(create_error_handler(opts))
     curl[opts.method](opts)
   end
 end

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -50,7 +50,7 @@ end
 local function create_error_handler(opts)
   return function(err)
     send_curl_stop_event(vim.tbl_extend("keep", { err = err }, opts))
-    vim.notify(vim.inspect(err.message), vim.log.levels.ERROR)
+    error(err.message)
   end
 end
 

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -18,7 +18,6 @@ rest.setup = function(user_configs)
   config.set(user_configs or {})
 end
 
-
 -- run will retrieve the required request information from the current buffer
 -- and then execute curl
 -- @param verbose toggles if only a dry run with preview should be executed (true = preview)
@@ -164,6 +163,7 @@ rest.run_request = function(req, opts)
   end
 
   Opts = {
+    request_id = vim.loop.now(), --random request id used to correlate RestStartRequest and RestStopRequest events
     method = result.method:lower(),
     url = result.url,
     -- plenary.curl can't set http protocol version
@@ -186,23 +186,7 @@ rest.run_request = function(req, opts)
     backend.highlight(result.bufnr, result.start_line, result.end_line)
   end
 
-  local request_id = vim.loop.now()
-  local data = {
-    requestId = request_id,
-    request = req,
-  }
-
-  vim.api.nvim_exec_autocmds("User", {
-    pattern = "RestStartRequest",
-    modeline = false,
-    data = data,
-  })
   local success_req, req_err = pcall(curl.curl_cmd, Opts)
-  vim.api.nvim_exec_autocmds("User", {
-    pattern = "RestStopRequest",
-    modeline = false,
-    data = vim.tbl_extend("keep", { status = success_req, message = req_err }, data),
-  })
 
   if not success_req then
     vim.api.nvim_err_writeln(

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -163,7 +163,7 @@ rest.run_request = function(req, opts)
   end
 
   Opts = {
-    request_id = vim.loop.now(), --random request id used to correlate RestStartRequest and RestStopRequest events
+    request_id = vim.loop.now(), -- request id used to correlate RestStartRequest and RestStopRequest events
     method = result.method:lower(),
     url = result.url,
     -- plenary.curl can't set http protocol version


### PR DESCRIPTION
Hello :)

Events implementation as proposed in [214](https://github.com/rest-nvim/rest.nvim/pull/214) seems to work incorrectly. 

Issue 1:
Because a `callback` function is passed to plenary's curl, the request will be made asynchronously, causing the `RestStopRequest` event to be emitted right after the `local success_req, req_err = pcall(curl.curl_cmd, Opts)` returns, way before the actual request finishes. 

Issue 2:
The events are emitted only during normal `run_request`, they are not emitted during rerunning the `last` request. 

Proposed changes: 
1. Move the emition of events into the `curl/init.lua` file. This way it won't matter if the call is made via `run_request` or `last` method.  I'm actually not sure about his one though. Maybe it would be better to extract the events back to the main `init.lua` file, however it was tempting how easy it was to implement. 
2. Emit the `RestStopRequest` inside the curl callback function. 
3. Add a `on_error` handler for plenary's curl. This allows us to emit the `RestStopRequest` event, when the request fails (.e.g. could not resolve the URL)  

The proposed changes will alter: 
1. The payload of `RestStartRequest`  and `RestStopRequest` - this can be some what mitigated I guess. However might be not a big deal, if the feature didn't worked correctly in the first place. 
2. The call stack of the emited error while calling `error(err.message)` in `create_error_handler`

Ofc.  I'm open to any suggestions :) 
I didn't had the time to check if this is in line with other PR that are currently open :(