### PR TITLE
test: use neorocks

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,12 @@
+return {
+  _all = {
+    coverage = false,
+    lpath = "lua/?.lua;lua/?/init.lua",
+  },
+  default = {
+    verbose = true
+  },
+  tests = {
+    verbose = true
+  },
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,37 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -15,7 +47,161 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "neorocks",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "neorocks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "neovim-nightly": "neovim-nightly",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1693223682,
+        "narHash": "sha256-4sMtKHBYYYcWut3Fb+172NnTwZ13Ya2HnAK0EsMslwE=",
+        "owner": "nvim-neorocks",
+        "repo": "neorocks",
+        "rev": "b5c0e1834f82f5d5af8dbc9c5a95d92865182e37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-neorocks",
+        "repo": "neorocks",
+        "type": "github"
+      }
+    },
+    "neovim-nightly": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "neorocks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dir": "contrib",
+        "lastModified": 1693178175,
+        "narHash": "sha256-qU3G9t6J22dpB4ofszt5dmzpA91+EV5hKgfSVm8ctCU=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "656be8a591a1fa1cba1de1a2128944d6a684cc7d",
+        "type": "github"
+      },
+      "original": {
+        "dir": "contrib",
+        "owner": "neovim",
+        "repo": "neovim",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1693145325,
+        "narHash": "sha256-Gat9xskErH1zOcLjYMhSDBo0JTBZKfGS0xJlIRnj6Rc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cddebdb60de376c1bdb7a4e6ee3d98355453fe56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1670751203,
         "narHash": "sha256-XdoH1v3shKDGlrwjgrNX/EN8s3c+kQV7xY6cLCE8vcI=",
@@ -31,10 +217,81 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_4",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "neorocks",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1692274144,
+        "narHash": "sha256-BxTQuRUANQ81u8DJznQyPmRsg63t4Yc+0kcyq6OLz8s=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "7e3517c03d46159fdbf8c0e5c97f82d5d4b0c8fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "neorocks": "neorocks",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,47 +4,61 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    neorocks.url = "github:nvim-neorocks/neorocks";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, neorocks, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
         mkDevShell = luaVersion:
           let
-            luaEnv = pkgs."lua${luaVersion}".withPackages (lp: with lp; [
+            luaEnv = pkgs."lua${luaVersion}".buildEnv.override {
+              extraLibs = with pkgs."lua${luaVersion}".pkgs; [
               busted
               luacheck
               luarocks
-            ]);
+              plenary-nvim
+
+            ];
+            # plenary vendors luassert
+            ignoreCollisions = true;
+          };
           in
           pkgs.mkShell {
             name = "rest-nvim";
             buildInputs = [
               pkgs.sumneko-lua-language-server
               luaEnv
+              neorocks.packages.${system}.neorocks
               pkgs.stylua
             ];
 
-            shellHook = let 
-              myVimPackage = with pkgs.vimPlugins; {
-                      start = [ plenary-nvim (nvim-treesitter.withPlugins (
+            shellHook =
+              let
+                myVimPackage = with pkgs.vimPlugins; {
+                  start = [
+                    plenary-nvim
+                    (nvim-treesitter.withPlugins (
                       plugins: with plugins; [
                         tree-sitter-lua
                         tree-sitter-http
                         tree-sitter-json
                       ]
-                    ))];
+                    ))
+                  ];
                 };
-              packDirArgs.myNeovimPackages = myVimPackage;
-            in 
+                packDirArgs.myNeovimPackages = myVimPackage;
+              in
               ''
-              export DEBUG_PLENARY="debug"
-              cat <<-EOF > minimal.vim
-                set rtp+=.
-                set packpath^=${pkgs.vimUtils.packDir packDirArgs}
-              EOF
+                export DEBUG_PLENARY="debug"
+                luarocks config --scope project lua_interpreter neolua
+
+                cat <<-EOF > minimal.vim
+                  set rtp+=.
+                  set packpath^=${pkgs.vimUtils.packDir packDirArgs}
+                EOF
               '';
           };
 
@@ -53,27 +67,29 @@
 
         devShells = {
           default = self.devShells.${system}.luajit;
-          ci = let 
-            neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
-              plugins = with pkgs.vimPlugins; [
-                { plugin = (nvim-treesitter.withPlugins (
-                    plugins: with plugins; [
-                      tree-sitter-lua
-                      tree-sitter-http
-                      tree-sitter-json
-                    ]
-                  ));
-                }
-                { plugin = plenary-nvim; }
-              ];
-              customRC = "";
-              wrapRc = false;
-            };
-            myNeovim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped neovimConfig;
-            in 
-              (mkDevShell "jit").overrideAttrs(oa: {
-                buildInputs = oa.buildInputs ++ [ myNeovim ];
-              });
+          ci =
+            let
+              neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
+                plugins = with pkgs.vimPlugins; [
+                  {
+                    plugin = (nvim-treesitter.withPlugins (
+                      plugins: with plugins; [
+                        tree-sitter-lua
+                        tree-sitter-http
+                        tree-sitter-json
+                      ]
+                    ));
+                  }
+                  { plugin = plenary-nvim; }
+                ];
+                customRC = "";
+                wrapRc = false;
+              };
+              myNeovim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped neovimConfig;
+            in
+            (mkDevShell "jit").overrideAttrs (oa: {
+              buildInputs = oa.buildInputs ++ [ myNeovim ];
+            });
 
           luajit = mkDevShell "jit";
           lua-51 = mkDevShell "5_1";
@@ -81,4 +97,3 @@
         };
       });
 }
-


### PR DESCRIPTION
This allows to use a neovim-aware lua interpreter
https://github.com/nvim-neorocks/neorocks/

`$ busted tests/` fails with
```

suite tests/main_spec.lua
...uajit-2.1.0-2022-10-04-env/share/lua/5.1/plenary/log.lua:9: attempt to index global 'vim' (a nil value)

stack traceback:
	...uajit-2.1.0-2022-10-04-env/share/lua/5.1/plenary/log.lua:9: in main chunk
```
but because it ignores the interpreter set in luarocks, which is why the command to run really should be `luarocks test` but in my case it tries to install the busted package and fails: the luarocks config should be updated to contain busted (via nixpkgs' generateLuarocksConfig for instance).