### PR TITLE
Fix request hightlight

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -45,6 +45,7 @@ rest.run_file = function(filename, opts)
   opts = vim.tbl_deep_extend(
     "force", -- use value from rightmost map
     defaultRequestOpts,
+    { highlight = config.get("highlight").enabled },
     opts or {}
   )
 
@@ -151,6 +152,7 @@ rest.run_request = function(req, opts)
   opts = vim.tbl_deep_extend(
     "force", -- use value from rightmost map
     defaultRequestOpts,
+    { highlight = config.get("highlight").enabled },
     opts or {}
   )
 


### PR DESCRIPTION
run_request and run_file request opts did not use the highlight.enabled setting from config, the default requestOpts prevented the current request to be hignlighted. Added the missing config to the creation of final request ops