### PR TITLE
[Feature] In-memory environment for post request scripts

### DIFF
--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -91,6 +91,7 @@ local function create_callback(curl_cmd, method, url, script_str)
         pretty_print = vim.pretty_print,
         json_decode = vim.fn.json_decode,
         set_env = utils.set_env,
+        set = utils.set_context,
       }
       local env = { context = context }
       setmetatable(env, { __index = _G })


### PR DESCRIPTION
It would be great if rest.nvim would support setting variables on running post request scripts without storing these values on hard disk, or without modifying existing .env files. This PR proposes a change for the post-script context and variable resolution to store values in an in-memory table and be able to resolve templates from these values as well. 

This in-memory context is bound to the currently used environment, so switching between them also switches between the in-memory stores as well.

Example situation where the IN_MEMORY_FIELD is available for resolution, but the runner not altering the .env file: 
```http
### First request
GET http://url/endpoint

{%
  local body = context.json_decode(context.result.body)
  context.set("IN_MEMORY_FIELD", body.field)
%}

### Second request
GET http://url/endpoint/{{IN_MEMORY_FIELD}}
```


