### PR TITLE
feat: stay in current window on split

### DIFF
--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -3,6 +3,7 @@ local M = {}
 local config = {
   result_split_horizontal = false,
   result_split_in_place = false,
+  stay_in_current_window_after_split = false,
   skip_ssl_verification = false,
   encode_url = true,
   highlight = {

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -217,7 +217,11 @@ local function create_callback(curl_cmd, opts)
       if config.get("result_split_in_place") then
         cmd_split = [[bel ]] .. cmd_split
       end
-      vim.cmd(cmd_split .. res_bufnr)
+      if config.get("stay_in_current_window_after_split") then
+        vim.cmd(cmd_split .. res_bufnr .. " | wincmd p")
+      else
+        vim.cmd(cmd_split .. res_bufnr)
+      end
       -- Set unmodifiable state
       vim.api.nvim_set_option_value("modifiable", false, { buf = res_bufnr })
     end


### PR DESCRIPTION
When you run request for this first time, focus is getting switched to the new windows with results buffer.
I've added simple flag that allows to configure this behavior: either stay in current windows (.http file) or change to results window (default)