### PR TITLE
feat: add request statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,11 @@ To run `rest.nvim` you should map the following commands:
 
 ### Statistics Spec
 
-| Property | Type            | Description                                            |
-| :------- | :-------------- | :----------------------------------------------------- |
-| [1]      | string          | `--write-out` variable name, see `man curl`. Required. |
-| title    | string          | Replaces the variable name in the output if defined.   |
-| type     | string|function | Specifies type transformation for the output value.
-Default transformers are `time` and `byte`. Can also be a function which takes the
-value as a parameter and returns a string. |
+| Property | Type               | Description                                            |
+| :------- | :----------------- | :----------------------------------------------------- |
+| [1]      | string             | `--write-out` variable name, see `man curl`. Required. |
+| title    | string             | Replaces the variable name in the output if defined.   |
+| type     | string or function | Specifies type transformation for the output value. Default transformers are `time` and `byte`. Can also be a function which takes the value as a parameter and returns a string. |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To run `rest.nvim` you should map the following commands:
 | :------- | :----------------- | :----------------------------------------------------- |
 | [1]      | string             | `--write-out` variable name, see `man curl`. Required. |
 | title    | string             | Replaces the variable name in the output if defined.   |
-| type     | string or function | Specifies type transformation for the output value. Default transformers are `time` and `byte`. Can also be a function which takes the value as a parameter and returns a string. |
+| type     | string or function | Specifies type transformation for the output value. Default transformers are `time` and `size`. Can also be a function which takes the value as a parameter and returns a string. |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ have to leave Neovim!
 
 - System-wide
   - curl
-- Optional [can be changed, see config bellow]
+- Optional [can be changed, see config below]
   - jq   (to format JSON output)
   - tidy (to format HTML output)
 - Other plugins
@@ -83,6 +83,9 @@ use {
         show_curl_command = false,
         show_http_info = true,
         show_headers = true,
+        -- table of curl `--write-out` variables or false if disabled
+        -- for more granular control see Statistics Spec
+        show_statistics = false,
         -- executables or functions for formatting response body [optional]
         -- set them to false if you want to disable them
         formatters = {
@@ -153,6 +156,16 @@ To run `rest.nvim` you should map the following commands:
 - `env_file` specifies file name that consist environment variables (default: .env)
 - `custom_dynamic_variables` allows to extend or overwrite built-in dynamic variable functions
     (default: {})
+
+### Statistics Spec
+
+| Property | Type            | Description                                            |
+| :------- | :-------------- | :----------------------------------------------------- |
+| [1]      | string          | `--write-out` variable name, see `man curl`. Required. |
+| title    | string          | Replaces the variable name in the output if defined.   |
+| type     | string|function | Specifies type transformation for the output value.
+Default transformers are `time` and `byte`. Can also be a function which takes the
+value as a parameter and returns a string. |
 
 ## Usage
 

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -14,6 +14,7 @@ local config = {
     show_url = true,
     show_http_info = true,
     show_headers = true,
+    show_statistics = false,
     formatters = {
       json = "jq",
       html = function(body)

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -175,6 +175,15 @@ local function create_callback(curl_cmd, opts)
       end
     end
 
+    if config.get("result").show_statistics then
+      -- Statistics, e.g. Total Time: 123.4 ms
+      local statistics
+
+      res.body, statistics = utils.parse_statistics(res.body)
+
+      utils.write_block(res_bufnr, statistics, true)
+    end
+
     --- Add the curl command results into the created buffer
     local formatter = config.get("result").formatters[content_type]
     -- format response body

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -158,6 +158,23 @@ rest.run_request = function(req, opts)
     spliced_body = splice_body(result.headers, result.body)
   end
 
+  if config.get("result").show_statistics then
+    local statistics_line = {}
+
+    for _, tbl in ipairs(config.get("result").show_statistics) do
+      if type(tbl) == "string" then
+        tbl = { tbl }
+      end
+
+      table.insert(statistics_line, tbl[1] .. "=%{" .. tbl[1] .. "}")
+    end
+
+    curl_raw_args = vim.tbl_extend("force", curl_raw_args, {
+      "--write-out",
+      "\\n" .. table.concat(statistics_line, "&"),
+    })
+  end
+
   Opts = {
     request_id = vim.loop.now(), -- request id used to correlate RestStartRequest and RestStopRequest events
     method = result.method:lower(),

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -532,7 +532,7 @@ local transform = {
     return time .. " " .. units[unit]
   end,
 
-  byte = function(bytes)
+  size = function(bytes)
     bytes = tonumber(bytes)
 
     local units = { "B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB" }
@@ -599,6 +599,12 @@ M.parse_statistics = function(body)
 
       if type(tbl.type) == "function" then
         value = tbl.type(value)
+      end
+    else
+      for key, fun in pairs(transform) do
+        if string.match(tbl[1], "^" .. key) then
+          value = fun(value)
+        end
       end
     end
 


### PR DESCRIPTION
This PR adds the option to configure statistics for requests with the curl `--write-out` option.

Statistics are added after the headers but before the body, and are by default disabled so this is an opt in feature and won't affect any existing configurations.

There are a couple of ways to configure statistics, either with a string or with a statistics spec. I didn't know how to properly convey this in the README.md, so any suggestions are welcome.

The two different config options are shown below and can be mixed together also.

```lua
{
  result = {
    show_statistics = { "time_total", "size_download" }
  }
}
```

```lua
{
  result = {
    show_statistics = {
      { "time_total", title = "Total time: ", type = "time" },
      { "size_download", type = "byte" },
  }
}
```

They will output respectively (queries ran on different endpoints, so their output doesn't match)

```bash
time_total 0.189020
size_download 154
```

```bash
Total time: 323.24 ms
size_download 6.96 KiB
```

depends #260
closes #256

Any feedback is welcome and I'll be happy to hear how I can improve my code.