### PR TITLE
feat: add buffer_name option

### DIFF
--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -33,6 +33,9 @@ local config = {
         }, body):gsub("\n$", "")
       end,
     },
+    buffer_name = function()
+      return 'rest_nvim_results'
+    end,
   },
   jump_to_request = false,
   env_file = ".env",

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -70,7 +70,38 @@ end
 -- get_or_create_buf checks if there is already a buffer with the rest run results
 -- and if the buffer does not exists, then create a new one
 M.get_or_create_buf = function()
-  local tmp_name = "rest_nvim_results"
+    vim.api.nvim_echo({
+      {
+        string.format("%s", config.get("result").buffer_name),
+        "Error",
+      },
+    }, false, {})
+  local tmp_name
+  local result_buffer_name = config.get("result").buffer_name
+  if type(result_buffer_name) == "function" then
+    local ok, out = pcall(result_buffer_name)
+    if ok and out and type(out) == "string" then
+      tmp_name = out
+    else
+      vim.api.nvim_echo({
+        {
+          string.format("config.result.buffer_name did not return a string"),
+          "Error",
+        },
+      }, false, {})
+      tmp_name = "rest_nvim_results"
+    end
+  elseif type(result_buffer_name) == "string" then
+    tmp_name = config.get("result").buffer_name
+  else
+    vim.api.nvim_echo({
+      {
+        string.format("config.result.buffer_name should be a function or a string"),
+        "Error",
+      },
+    }, false, {})
+    tmp_name = "rest_nvim_results"
+  end
 
   -- Check if the file is already loaded in the buffer
   local existing_bufnr = vim.fn.bufnr(tmp_name)


### PR DESCRIPTION
Hi! It would be nice to have the ability to keep multiple result buffers open at the same time, like in [diepm/vim-rest-console](https://github.com/diepm/vim-rest-console#42-multiple-vrc-buffers), I'm guessing adding an option would be the most flexible way.

You could check a buffer variable like in vim-rest-console:

```lua
buffer_name = function()
  return vim.b.rest_nvim_result_buffer or 'rest_nvim_results'
end
```

Thanks, let me know any questions or review' comments.