### PR TITLE
fix: return non json body

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -129,6 +129,7 @@ local function splice_body(headers, payload)
       return vim.fn.json_encode(json_body)
     end
   end
+  return body
 end
 
 -- run will retrieve the required request information from the current buffer


### PR DESCRIPTION
fix for non json body like form data:

```http
POST https://httpbin.org/post
Content-Type: application/x-www-form-urlencoded

a=1&b=2
```