### PR TITLE
Telescope extension can select env files ignored by git

### DIFF
--- a/lua/telescope/_extensions/rest.lua
+++ b/lua/telescope/_extensions/rest.lua
@@ -20,7 +20,7 @@ local function rest_env_select(opt)
   local pattern = config.get("env_pattern")
   local edit = config.get("env_edit_command")
 
-  local command = string.format("fd -H '%s'", pattern)
+  local command = string.format("fd -HI '%s'", pattern)
   local result = io.popen(command):read("*a")
 
   local lines = {}


### PR DESCRIPTION
When trying to select an environment file with the Telescope extension, the underlying `fd -H` command would match hidden files, but not files that are matched by `.gitignore`. Adding the `-I` option matches files that are ignored by git.

Fixes #283 