### PR TITLE
Add pre-script configuration.

### DIFF
--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -22,6 +22,7 @@ CONTENTS                                                   *rest-nvim-contents*
         4. Environment Variables........|rest-nvim-usage-environment-variables|
         5. Dynamic Variables................|rest-nvim-usage-dynamic-variables|
         6. Callbacks................................|rest-nvim-usage-callbacks|
+        7. Pre-script..............................|rest-nvim-usage-pre-script|
     5. Known issues..........................................|rest-nvim-issues|
     6. License..............................................|rest-nvim-license|
     7. Contributing....................................|rest-nvim-contributing|
@@ -238,6 +239,31 @@ rest.nvim fires different events upon requests:
 	 print("IT STARTED")
 	 vim.pretty_print(opts)
       end,
+    })
+<
+===============================================================================
+Pre-Script                                           *rest-nvim-usage-pre-script*
+
+rest.nvim allows configuring a pre-script that is invoked before launching a
+request. This script can be used to dynamically modify the request headers and
+body. The script receives the request opts and environment variables: >lua
+
+    -- pre-script example:
+    require("rest-nvim").setup({
+      request = {
+	pre_script = function(opts, variables)
+	  -- Access request body
+	  local body = opts["body"]
+	  -- Access request headers
+	  local content_type = opts["headers"]["Content-Type"]
+	  -- Access environment variables
+	  local secret_key = variables["SECRET_KEY"]
+
+	  -- Set custom request headers.
+	  opts["headers"]["X-Signature"] = signature(body, secret_key)
+	  opts["headers"]["X-Timestamp"] = os.time
+	end
+      },
     })
 <
 ===============================================================================

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -10,6 +10,10 @@ local config = {
     enabled = true,
     timeout = 150,
   },
+  request = {
+    pre_script = function()
+    end
+  },
   result = {
     show_curl_command = true,
     show_url = true,

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -276,6 +276,12 @@ end
 --           - yank_dry_run (boolean): displays the command
 --           - arguments are forwarded to plenary
 M.curl_cmd = function(opts)
+
+  --- Execute request pre-script if any.
+  if config.get("request").pre_script then
+    config.get("request").pre_script(opts, utils.get_variables())
+  end
+
   -- plenary's curl module is strange in the sense that with "dry_run" it returns the command
   -- otherwise it starts the request :/
   local dry_run_opts = vim.tbl_extend("force", opts, { dry_run = true })

--- a/lua/telescope/_extensions/rest.lua
+++ b/lua/telescope/_extensions/rest.lua
@@ -16,7 +16,7 @@ local conf = require("telescope.config").values
 
 local config = require("rest-nvim.config")
 
-local function rest_env_select(opt)
+local function rest_env_select(_)
   local pattern = config.get("env_pattern")
   local edit = config.get("env_edit_command")
 


### PR DESCRIPTION
Adds a new configuration option that allows to set a lua script that is executed before each request. This script receives the request opts (body, headers, url, etc.) and the environment variables.

This allows to dynamically modify the opts (body, headers, url, etc.) before executing the request. For example compute some signature based on the request body and some key to set the Authorization header etc.