### PR TITLE
docs: add `ft` to `lazy.nvim` config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ use {
 return {
    "rest-nvim/rest.nvim",
    dependencies = { { "nvim-lua/plenary.nvim" } },
+   ft = 'http',
    config = function()
      require("rest-nvim").setup({
        --- Get the same options from Packer setup


### PR DESCRIPTION
Without this, the filetype is not applied correctly.
#184 