### PR TITLE
Get json content type for custom content types

### DIFF
--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -133,7 +133,13 @@ local function create_callback(curl_cmd, opts)
 
     local content_type = res.headers[utils.key(res.headers, "content-type")]
     if content_type then
-      content_type = content_type:match("application/([-a-z]+)") or content_type:match("text/(%l+)")
+      local isJson = content_type:match("application/.+(json)")
+
+      if isJson then
+        content_type = "json"
+      else
+        content_type = content_type:match("application/([-a-z]+)") or content_type:match("text/(%l+)")
+      end
     end
 
     if script_str ~= nil then


### PR DESCRIPTION
I have found a bug using the contentful api. This api returns this content type: 
```
Content-Type: application/vnd.contentful.delivery.v1+json
```
Currently the content type is `vnd` instead of `json`. 

I have added this fix, but I think can be improved  extending to all the content types this plugin want to support, probably are only 3: json, html and txt. let me know what you think, and thanks for this great plugin 🎉   