### PR TITLE
fix: ensure help window width is an int

### DIFF
--- a/lua/rest-nvim/result/help.lua
+++ b/lua/rest-nvim/result/help.lua
@@ -62,7 +62,7 @@ function help.open()
   end
 
   -- Help window sizing and positioning
-  local width = vim.api.nvim_win_get_width(winnr) / 2
+  local width = math.floor(vim.api.nvim_win_get_width(winnr) / 2)
   local height = 8
 
   local col = vim.api.nvim_win_get_width(winnr) - width - 4


### PR DESCRIPTION
Copied from the body of the commit:

> Problem:
> 
> The help window causes an error when calling `vim.api.nvim_open_win` because the width being passed is not an integer.
> 
> Neovim's `vim.api.nvim_open_win` function requires that the width and height be specified in whole integers.
> 
> The width is being calculated through a division operation causing it to potentially be a number that is not an int.
> 
> Solution:
> 
> Floor the calculation of the help window width so the width is always rounded down to the nearest integer and can thus be used with `vim.api.nvim_open_win`.
