### PR TITLE
fix(parser): make `parse_request` handle `request` TS nodes

### DIFF
--- a/lua/rest-nvim/parser/init.lua
+++ b/lua/rest-nvim/parser/init.lua
@@ -221,6 +221,8 @@ function parser.parse_request(children_nodes, variables)
     elseif node_type == "http_version" then
       local http_version = assert(get_node_text(node, 0))
       request.http_version = http_version:gsub("HTTP/", "")
+    elseif node_type == "request" then
+      request = parser.parse_request(traverse_request(node), variables)
     end
   end
 


### PR DESCRIPTION
Copied from the body of the commit:

> Problem:
> 
> Placing cursor between a request method and a uri and then invoking `:Rest run` causes the node to be incorrectly parsed leading to an error.
> 
> See the following where the column above the caret (^) denotes the cursor position:
> 
> ```
> GET https://google.com
>    ^ cursor above caret
> ```
> 
> Running this will cause an error. This is because the `parser.parse_request` method cannot handle Treesitter nodes of type `request`.
> 
> Solution:
> 
> Make the `parser.parse_request` function handle Treesitter nodes of type `request` by recursively calling itself on the `request` node and taking that output when it finds a `request` node.

Example of the problem with a recording:
![rest-nvim-parser-bug](https://github.com/rest-nvim/rest.nvim/assets/58627896/0426a765-4192-401a-89ab-de938b770d0d)


This problem implies a deeper issue to my eyes as I noticed there's a function `parser.look_behind_until` that's supposed to get the top level `request` node I assume. I don't know enough about the code of `rest.nvim` to make a strong statement beyond this unfortunately 🙁.

I'm making this PR because it certainly solves the problem noted above, but I don't know if it's the *best* solution. If you know a better way of doing this please advise, I'll gladly close this PR and fix the underlying issue with some guidance (assuming there actually is an underlying issue).