### PR TITLE
chore: set `lua` indent_size in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.lua]
+indent_size = 2
+
 [*.{md,lua}]
 max_line_length = 100
 


### PR DESCRIPTION
Neovim supports `editorconfig` now, it has a builtin plugin for it. See `:h editorconfig`.

This change ensures editors pick up the correct `indent_size` (like Neovim) and set their indent sizing correctly.

`stylua.toml` is using the indent size as 2, so I set all lua files to use an indent size of 2 as well in the editorconfig.

It was driving me a tiny bit bonkers having to run `:set shifwidth=2` on every lua file while working on something else 😄.

