### PR TITLE
docs(README): update instructions to adapt to latest `luarocks.nvim` changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,26 +67,13 @@ CLI. For more information on this, please see this [blog post](https://amartin.c
 :Rocks install rest.nvim
 ```
 
-### [packer.nvim](https://github.com/wbthomason/packer.nvim)
-
-```lua
-use {
-  "rest-nvim/rest.nvim",
-  rocks = { "lua-curl", "nvim-nio", "mimetypes", "xml2lua" },
-  config = function()
-    require("rest-nvim").setup()
-  end,
-}
-```
-
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
 {
   "vhyrro/luarocks.nvim",
-  config = function()
-    require("luarocks").setup({})
-  end,
+  priority = 1000,
+  config = true,
 },
 {
   "rest-nvim/rest.nvim",
@@ -101,7 +88,20 @@ use {
 > [!NOTE]
 >
 > There's a `build.lua` file in the repository that `lazy.nvim` will find and source to install the
-> luarocks dependencies for you by using `luarocks.nvim`.
+> luarocks dependencies for you by using `luarocks.nvim`. You don't need to specify a rock list
+> by yourself.
+
+### [packer.nvim](https://github.com/wbthomason/packer.nvim)
+
+```lua
+use {
+  "rest-nvim/rest.nvim",
+  rocks = { "lua-curl", "nvim-nio", "mimetypes", "xml2lua" },
+  config = function()
+    require("rest-nvim").setup()
+  end,
+}
+```
 
 ### Default configuration
 


### PR DESCRIPTION
This PR updates the rest.nvim README with the newest changes related to luarocks.nvim. Once this gets merged I'll also merge the luarocks.nvim `go-away-python` branch into `main`.

The `go-away-python` branch removes the need for python as an external dependency, completely eliminates hererocks, fixes several bugs on different platforms and generally tries to provide a more streamlined experience. That does come unfortunately at the cost of a breaking change, but such is life sometimes :)

 This will probably be the last breaking change luarocks.nvim has in a *while*.