### PR TITLE
fix(functions): handle highlights of winbar result with prefixed zeros

### DIFF
--- a/lua/rest-nvim/result/winbar.lua
+++ b/lua/rest-nvim/result/winbar.lua
@@ -62,7 +62,9 @@ local function get_hl_group_fg(name)
   -- If the HEX color has a zero as the first character, `string.format` will skip it
   -- so we have to add it manually later
   local hl_fg = string.format("%02X", vim.api.nvim_get_hl(0, { name = name, link = false }).fg)
-  if #hl_fg == 5 then
+  if #hl_fg == 4 then
+    hl_fg = "00" .. hl_fg
+  elseif #hl_fg == 5 then
     hl_fg = "0" .. hl_fg
   end
   hl_fg = "#" .. hl_fg


### PR DESCRIPTION
This should avoid errors as reported on issue #339