### PR TITLE
feat: custom mappings for cycle result pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ local default_config = {
           return fmt_body, { found = true, name = "tidy" }
         end,
       },
+      keybinds = {
+        buffer_local = false,
+        prev = "H",
+        next = "L",
+      },
     },
   },
   highlight = {

--- a/lua/rest-nvim/autocmds.lua
+++ b/lua/rest-nvim/autocmds.lua
@@ -30,10 +30,16 @@ function autocmds.setup()
     callback = function(args)
       vim.keymap.set("n", "H", function()
         functions.cycle_result_pane("prev")
-      end, { desc = "Go to previous winbar pane" })
+      end, {
+        desc = "Go to previous winbar pane",
+        buffer = args.buf,
+      })
       vim.keymap.set("n", "L", function()
         functions.cycle_result_pane("next")
-      end, { desc = "Go to next winbar pane" })
+      end, {
+        desc = "Go to next winbar pane",
+        buffer = args.buf,
+      })
       vim.keymap.set("n", "?", result_help.open, {
         desc = "Open rest.nvim request results help window",
         buffer = args.buf,

--- a/lua/rest-nvim/autocmds.lua
+++ b/lua/rest-nvim/autocmds.lua
@@ -15,6 +15,7 @@ local result_help = require("rest-nvim.result.help")
 ---Set up Rest autocommands group and set `:Rest` command on `*.http` files
 function autocmds.setup()
   local rest_nvim_augroup = vim.api.nvim_create_augroup("Rest", {})
+  local keybinds = _G._rest_nvim.result.keybinds
   vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
     group = rest_nvim_augroup,
     pattern = "*.http",
@@ -28,17 +29,17 @@ function autocmds.setup()
     group = rest_nvim_augroup,
     pattern = "rest_nvim_results",
     callback = function(args)
-      vim.keymap.set("n", "H", function()
+      vim.keymap.set("n", keybinds.prev, function()
         functions.cycle_result_pane("prev")
       end, {
         desc = "Go to previous winbar pane",
-        buffer = args.buf,
+        buffer = keybinds.buffer_local and args.buf or nil,
       })
-      vim.keymap.set("n", "L", function()
+      vim.keymap.set("n", keybinds.next, function()
         functions.cycle_result_pane("next")
       end, {
         desc = "Go to next winbar pane",
-        buffer = args.buf,
+        buffer = keybinds.buffer_local and args.buf or nil,
       })
       vim.keymap.set("n", "?", result_help.open, {
         desc = "Open rest.nvim request results help window",

--- a/lua/rest-nvim/config/check.lua
+++ b/lua/rest-nvim/config/check.lua
@@ -58,6 +58,11 @@ function check.validate(cfg)
     formatters = { cfg.result.behavior.formatters, "table" },
     json = { cfg.result.behavior.formatters.json, { "string", "function" } },
     html = { cfg.result.behavior.formatters.html, { "string", "function" } },
+    -- RestConfigResultKeybinds
+    result_keybinds = { cfg.result.keybinds, "table" },
+    prev = { cfg.result.keybinds.prev, "string" },
+    next = { cfg.result.keybinds.next, "string" },
+    buffer_local = { cfg.result.keybinds.buffer_local, "boolean" },
     -- RestConfigHighlight
     highlight_enable = { cfg.highlight.enable, "boolean" },
     timeout = { cfg.highlight.timeout, "number" },

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -126,6 +126,11 @@ local default_config = {
         end,
       },
     },
+    keybinds = {
+      buffer_local = false,
+      prev = "H",
+      next = "L",
+    },
   },
   highlight = {
     enable = true,

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -20,6 +20,7 @@ local logger = require("rest-nvim.logger")
 ---@class RestConfigResult
 ---@field split RestConfigResultSplit Result split window behavior
 ---@field behavior RestConfigResultBehavior Result buffer behavior
+---@field keybinds RestConfigResultKeybinds Keybinds settings to navigate throught request results
 
 ---@class RestConfigResultSplit
 ---@field horizontal boolean Open request results in a horizontal split
@@ -45,6 +46,11 @@ local logger = require("rest-nvim.logger")
 ---@class RestConfigResultFormatters
 ---@field json string|fun(body: string): string,table JSON formatter
 ---@field html string|fun(body: string): string,table HTML formatter
+
+---@class RestConfigResultKeybinds
+---@field buffer_local boolean Enable keybinds only in request result buffer
+---@field prev string Mapping for cycle to previous result pane
+---@field next string Mapping for cycle to next result pane
 
 ---@class RestConfigHighlight
 ---@field enable boolean Whether current request highlighting is enabled or not

--- a/lua/rest-nvim/result/help.lua
+++ b/lua/rest-nvim/result/help.lua
@@ -26,6 +26,7 @@ local function get_or_create_buf()
   if not existing_buf then
     -- Create a new buffer
     local new_bufnr = vim.api.nvim_create_buf(false, true)
+    local keybinds = _G._rest_nvim.result.keybinds
     vim.api.nvim_buf_set_name(new_bufnr, tmp_name)
     vim.api.nvim_set_option_value("ft", "markdown", { buf = new_bufnr })
     vim.api.nvim_set_option_value("buftype", "nofile", { buf = new_bufnr })
@@ -35,8 +36,8 @@ local function get_or_create_buf()
       "**`rest.nvim` results window help**",
       "",
       "**Keybinds**:",
-      "  - `H`: go to previous pane",
-      "  - `L`: go to next pane",
+      "  - `" .. keybinds.prev .. "`: go to previous pane",
+      "  - `" .. keybinds.next .. "`: go to next pane",
       "  - `q`: close results window",
       "",
       "**Press `q` to close this help window**",


### PR DESCRIPTION
There was added new table in `result` table named `keybinds`. With this table you can redefine mapping for `cycle_result_pane` action. To do this, in config you need to add
```lua
result = {
  keybinds = {
    prev = "J", -- or any
    next = "K", -- or any
  }
}
```

Other feature is ability to choose does these mappings attach to request result buffer or not. If you want to make mappings locally in buffer, add
```lua
result = {
  keybinds = {
    -- ...
    buffer_local = true
  }
}
```
This feature is useful if you already have other actions mapped with `H` or `L`.

Defaults for `result.keybinds` are following:
```lua
keybinds = {
  buffer_local = false,
  prev = "H",
  next = "L",
}
```
So plugin acts like before if `keybinds` is not set.