### PR TITLE
fix: correctly urlencode query parameters

### DIFF
--- a/lua/rest-nvim/client/curl.lua
+++ b/lua/rest-nvim/client/curl.lua
@@ -204,7 +204,13 @@ function client.request(request)
       local _url = curl.url()
       _url:set_url(request.request.url)
       -- Re-add the request query with the encoded parameters
-      _url:set_query(_url:get_query(), curl.U_URLENCODE)
+      local query = _url:get_query()
+      if type(query) == "string" then
+        _url:set_query('')
+        for param in vim.gsplit(query, "&") do
+          _url:set_query(param, curl.U_URLENCODE + curl.U_APPENDQUERY)
+        end
+      end
       -- Re-add the request URL to the req object
       req:setopt_url(_url:get_url())
     end


### PR DESCRIPTION
Fixes #317 

Splits the query into individual parameters and appends each one to the url using the `U_APPENDQUERY` flag. Handling of the `=` character is not needed due to how the flag works:

> When [CURLU_APPENDQUERY](https://curl.se/libcurl/c/curl_url_set.html#CURLUAPPENDQUERY) is used together with [CURLU_URLENCODE](https://curl.se/libcurl/c/curl_url_set.html#CURLUURLENCODE), the first '=' symbol is not URL encoded.

See https://curl.se/libcurl/c/curl_url_set.html#CURLUAPPENDQUERY