### PR TITLE
fix: change default HL behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ local default_config = {
         end,
       },
       keybinds = {
-        buffer_local = false,
+        buffer_local = true,
         prev = "H",
         next = "L",
       },

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -133,7 +133,7 @@ local default_config = {
       },
     },
     keybinds = {
-      buffer_local = false,
+      buffer_local = true,
       prev = "H",
       next = "L",
     },


### PR DESCRIPTION
Instead of global keymaps only HL for switching tabs when focused on that buffer as the default behavior.