### PR TITLE
docs(README.md): fix the config to match what the code expects

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ local default_config = {
           return fmt_body, { found = true, name = "tidy" }
         end,
       },
-      keybinds = {
-        buffer_local = true,
-        prev = "H",
-        next = "L",
-      },
+    },
+    keybinds = {
+      buffer_local = true,
+      prev = "H",
+      next = "L",
     },
   },
   highlight = {


### PR DESCRIPTION
The `keybinds` field used for navigating the tabs for the results was under `results.behavior.keybinds` instead of `results.keybinds`. I checked the code [here](https://github.com/rest-nvim/rest.nvim/blob/main/lua/rest-nvim/config/check.lua#L61-L65) to figure out the correct setup, as `results.behavior.keybinds` was producing the following error:
```
[rest.nvim] WARN: Unrecognized configs found in setup: { "result.behavior.keybinds" }
```