### PR TITLE
docs: add missing dependencies for lazy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ CLI. For more information on this, please see this [blog post](https://amartin.c
   "vhyrro/luarocks.nvim",
   priority = 1000,
   config = true,
+  opts = {
+    rocks = { "lua-curl", "nvim-nio", "mimetypes", "xml2lua" }
+  }
 },
 {
   "rest-nvim/rest.nvim",


### PR DESCRIPTION
Fixed README instructions to include missing dependencies for automatic LuaRocks installation