### PR TITLE
refactor: remove luanil opts for vim.json.decode

### DIFF
--- a/lua/rest-nvim/parser/init.lua
+++ b/lua/rest-nvim/parser/init.lua
@@ -338,9 +338,7 @@ function parser.parse_body(children_nodes, variables)
   for node_type, node in pairs(children_nodes) do
     if node_type == "json_body" then
       local json_body_text = assert(get_node_text(node, 0))
-      local json_body = vim.json.decode(json_body_text, {
-        luanil = { object = true, array = true },
-      })
+      local json_body = vim.json.decode(json_body_text)
       body = traverse_body(json_body, variables)
       -- This is some metadata to be used later on
       body.__TYPE = "json"


### PR DESCRIPTION
This PR removes the luanil opts from the `vim.json.decode`, since when they are provided all instances of key-value pairs with null values are removed, see my issue in [neovim](https://github.com/neovim/neovim/issues/28619). lua-tables cannot hold nil values:

```
Like indices, the value of a table field can be of any type (except `nil`). In
particular, because functions are first-class values, table fields may contain
functions. Thus tables may also carry methods (see |lua-function-define|).
```

which is the root cause to this behavior.