### PR TITLE
fix: set regtype "v"

### DIFF
--- a/lua/rest-nvim/utils.lua
+++ b/lua/rest-nvim/utils.lua
@@ -139,7 +139,7 @@ function utils.highlight(bufnr, start, end_, ns)
     higroup,
     { start, 0 },
     { end_, string.len(vim.fn.getline(end_)) },
-    { regtype = "c", inclusive = false }
+    { regtype = "v", inclusive = false }
   )
 
   -- Clear buffer highlights again after timeout


### PR DESCRIPTION
regtype is currently set to "c" which is invalid and does not work on nvim 0.11. This patch replace "c" with "v", which I assume is the correct type (at least it works as intended when I tested it).

```
getregtype([{regname}])                                           *getregtype()*
		The result is a String, which is type of register {regname}.
		The value will be one of:
		    "v"			for |charwise| text
		    "V"			for |linewise| text
		    "<CTRL-V>{width}"	for |blockwise-visual| text
		    ""			for an empty or unknown register
		<CTRL-V> is one character with value 0x16.
		The {regname} argument is a string.  If {regname} is not
		specified, |v:register| is used.
```