### PR TITLE
fix: run highlight callback on same buffer

### DIFF
--- a/lua/rest-nvim/functions.lua
+++ b/lua/rest-nvim/functions.lua
@@ -63,7 +63,7 @@ function functions.exec(scope)
       parser.look_behind_until(parser.get_node_at_cursor(), "request")
     )
 
-    utils.highlight(0, req.start, req.end_, api.namespace)
+    utils.highlight(vim.api.nvim_get_current_buf(), req.start, req.end_, api.namespace)
 
     -- Set up a _rest_nvim_req_data Lua global table that holds the parsed request
     -- so the values can be modified from the pre-request hooks
@@ -94,7 +94,7 @@ function functions.exec(scope)
       ---@diagnostic disable-next-line need-check-nil
       logger:error("Rest run last: A previously made request was not found to be executed again")
     else
-      utils.highlight(0, req.start, req.end_, api.namespace)
+      utils.highlight(vim.api.nvim_get_current_buf(), req.start, req.end_, api.namespace)
 
       -- Set up a _rest_nvim_req_data Lua global table that holds the parsed request
       -- so the values can be modified from the pre-request hooks


### PR DESCRIPTION
i have the following config set:
```
config = {
  result = {
    split = {
      stay_in_current_window_after_split = false,
    },
  },
}
```

but with this, i noticed that whenever i ran a request and my cursor switched buffers to the response, my request was permanently highlighted.  It looks like this is because the call to `utils.highlight` uses `bufnr = 0`, meaning that the deffered call to `vim.api.nvim_buf_clear_namespace` will (most likely) run in the response buffer.

so i just changed this to use the exact `bufnr` so the callback function only runs on the buffer that was initially highlighted.