### PR TITLE
fix(parse http time): update lua pattern to support hyphen separated date

### DIFF
--- a/lua/rest-nvim/utils.lua
+++ b/lua/rest-nvim/utils.lua
@@ -84,7 +84,7 @@ function utils.read_file(path)
 end
 
 function utils.parse_http_time(time_str)
-    local pattern = "(%a+), (%d+)[\\s-](%a+)[\\s-](%d+) (%d+):(%d+):(%d+) GMT"
+    local pattern = "(%a+), (%d+)[%s-](%a+)[%s-](%d+) (%d+):(%d+):(%d+) GMT"
     local _, day, month_name, year, hour, min, sec = time_str:match(pattern)
   -- stylua: ignore
   local months = {

--- a/lua/rest-nvim/utils.lua
+++ b/lua/rest-nvim/utils.lua
@@ -84,7 +84,7 @@ function utils.read_file(path)
 end
 
 function utils.parse_http_time(time_str)
-    local pattern = "(%a+), (%d+) (%a+) (%d+) (%d+):(%d+):(%d+) GMT"
+    local pattern = "(%a+), (%d+)[\\s-](%a+)[\\s-](%d+) (%d+):(%d+):(%d+) GMT"
     local _, day, month_name, year, hour, min, sec = time_str:match(pattern)
   -- stylua: ignore
   local months = {


### PR DESCRIPTION
This patch updates the regex pattern for the time_str to support the format `Tue, 18-Feb-2025 09:59:46 GMT`