### PR TITLE
fix(statistics): allow all curl statistics, ordering, highlight

### DIFF
--- a/lua/rest-nvim/client/curl/cli.lua
+++ b/lua/rest-nvim/client/curl/cli.lua
@@ -247,14 +247,12 @@ function builder.statistics()
     if vim.tbl_isempty(config.clients.curl.statistics) then
         return
     end
-    local args = { "-w" }
     local format = vim.iter(config.clients.curl.statistics)
-        :map(function(key, _style)
-            return ("? %s:%%{%s}\n"):format(key, key)
+        :map(function(style)
+            return ("? %s:%%{%s}\n"):format(style.id, style.id)
         end)
         :join("")
-    table.insert(args, "%{stderr}" .. format)
-    return args
+    return { "-w", "%{stderr}" .. format }
 end
 
 ---@package

--- a/lua/rest-nvim/config/check.lua
+++ b/lua/rest-nvim/config/check.lua
@@ -86,6 +86,11 @@ function check.get_unrecognized_keys(tbl, default_tbl)
             end
         end
     end
+    for k, _ in pairs(ret) do
+        if k:find("statistics") then
+            ret[k] = nil
+        end
+    end
 
     return vim.tbl_keys(ret)
 end

--- a/lua/rest-nvim/config/check.lua
+++ b/lua/rest-nvim/config/check.lua
@@ -105,7 +105,7 @@ function check.get_unrecognized_keys(tbl, default_tbl)
         end
     end
     for k, _ in pairs(ret) do
-        if k:find("statistics") then
+        if type(k) == "string" and k:find("statistics") then
             ret[k] = nil
         end
     end

--- a/lua/rest-nvim/config/default.lua
+++ b/lua/rest-nvim/config/default.lua
@@ -39,8 +39,8 @@ local default_config = {
             ---See `man curl` for `--write-out` flag
             ---@type table<string,RestStatisticsStyle>
             statistics = {
-                time_total = { winbar = "take", title = "Time taken" },
-                size_download = { winbar = "size", title = "Download size" },
+                time_total = { winbar = "take", title = "Time taken", order = 1 },
+                size_download = { winbar = "size", title = "Download size", order = 2 },
             },
         },
     },

--- a/lua/rest-nvim/config/default.lua
+++ b/lua/rest-nvim/config/default.lua
@@ -37,10 +37,10 @@ local default_config = {
         curl = {
             ---Statistics to be shown, takes cURL's `--write-out` flag variables
             ---See `man curl` for `--write-out` flag
-            ---@type table<string,RestStatisticsStyle>
+            ---@type RestStatisticsStyle[]
             statistics = {
-                time_total = { winbar = "take", title = "Time taken", order = 1 },
-                size_download = { winbar = "size", title = "Download size", order = 2 },
+                { id = "time_total", winbar = "take", title = "Time taken" },
+                { id = "size_download", winbar = "size", title = "Download size" },
             },
         },
     },

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -61,18 +61,17 @@ local config
 
 ---@class rest.Opts.Clients.Curl
 --- Statistics to parse from curl request output
---- Key is a string value of format used in `--write-out` option
---- See `man curl` for more info
----@field statistics? table<string,RestStatisticsStyle>
+---@field statistics? RestStatisticsStyle[]
 
 ---@class RestStatisticsStyle
+--- Identifier used used in curl's `--write-out` option
+--- See `man curl` for more info
+---@field id string
 --- Title used on Statistics pane
 ---@field title? string
 --- Winbar title. Set to `false` or `nil` to not show for winbar, set to empty string
 --- to hide title If true, rest.nvim will use lowered `title` field
 ---@field winbar? string|boolean
---- Order position from low to high
----@field order? number
 
 ---@class rest.Opts.Cookies
 --- Enable the cookies support (Default: `true`)

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -71,6 +71,8 @@ local config
 --- Winbar title. Set to `false` or `nil` to not show for winbar, set to empty string
 --- to hide title If true, rest.nvim will use lowered `title` field
 ---@field winbar? string|boolean
+--- Order position from low to high
+---@field order? number
 
 ---@class rest.Opts.Cookies
 --- Enable the cookies support (Default: `true`)

--- a/lua/rest-nvim/ui/result.lua
+++ b/lua/rest-nvim/ui/result.lua
@@ -161,23 +161,11 @@ local panes = {
                 set_lines(self.bufnr, { "No Statistics" })
                 return
             end
-            vim.bo[self.bufnr].syntax = "http_stat"
-
-            local ordered = {}
-            for key, value in pairs(data.response.statistics) do
-                local style = config.clients.curl.statistics[key] or {}
-                local title = style["title"] or key
-
-                table.insert(ordered, {
-                    order = style.order or 0,
-                    val = ("%s: %s"):format(title, value),
-                })
-            end
-            table.sort(ordered, function(a, b)
-                return a.order < b.order
-            end)
-            for _, v in ipairs(ordered) do
-                table.insert(lines, v.val)
+            syntax_highlight(self.bufnr, "http_stat")
+            for _, style in ipairs(config.clients.curl.statistics) do
+                local title = style.title or style.id
+                local value = data.response.statistics[style.id] or ""
+                table.insert(lines, ("%s: %s"):format(title, value))
             end
             set_lines(self.bufnr, lines)
         end,
@@ -193,32 +181,19 @@ winbar = winbar .. "%#RestText#Press %#Keyword#?%#RestText# for help%#Normal# "
 ---Winbar component showing response statistics
 ---@return string
 function ui.stat_winbar()
+    local content = ""
     if not data.response then
         return "Loading...%#Normal#"
     end
-    local ordered = {}
-    for stat_name, style in pairs(config.clients.curl.statistics) do
-        local stat_value = data.response.statistics[stat_name] or ""
+    for _, style in ipairs(config.clients.curl.statistics) do
         if style.winbar then
-            local title = type(style.winbar) == "string" and style.winbar or (style.title or stat_name):lower()
+            local title = type(style.winbar) == "string" and style.winbar or (style.title or style.id):lower()
             if title ~= "" then
                 title = title .. ": "
             end
-            table.insert(ordered, {
-                order = style.order or 0,
-                val = string.format("%%#RestText#%s%%#Normal#%s", title, stat_value),
-            })
+            local value = data.response.statistics[style.id] or ""
+            content = content .. "  %#RestText#" .. title .. "%#Normal#" .. value
         end
-    end
-    if #ordered == 0 then
-        return ""
-    end
-    table.sort(ordered, function(a, b)
-        return a.order < b.order
-    end)
-    local content = ""
-    for _, v in ipairs(ordered) do
-        content = content .. " " .. v.val
     end
     return content
 end

--- a/rest.nvim-scm-1.rockspec
+++ b/rest.nvim-scm-1.rockspec
@@ -50,5 +50,6 @@ build = {
     "ftdetect",
     "ftplugin",
     "queries",
+    "syntax",
   }
 }

--- a/syntax/http_stat.vim
+++ b/syntax/http_stat.vim
@@ -1,0 +1,9 @@
+if exists("b:current_syntax") | finish | endif
+
+syntax match httpStatField "^\s*\zs.\{-}\ze:"
+syntax match httpStatValue ": \zs.*$"
+
+highlight link httpStatField Identifier
+highlight link httpStatValue String
+
+let b:current_syntax = "http_stat"


### PR DESCRIPTION
Hello, If I add more statistics like 
```lua
        vim.g.rest_nvim = {
            clients = {
                curl = {
                    statistics = {
                        remote_ip = { winbar = "ip", title = "Remote IP" },
                        time_total = { winbar = "time", title = "Time" },
                        time_namelookup = { title = "Time dns" },
                        time_connect = { title = "Time connect" },
                        time_pretransfer = { title = "Time pretransfer" },
                        time_redirect = { title = "Time redirect" },
                        time_starttransfer = { title = "Time starttransfer" },
                        size_download = { title = "Download size", winbar = false },
                        speed_download = { title = "Download speed", },
                        size_upload = { title = "Upload size" },
                        speed_upload = { title = "Upload speed" },
                    },
                },
            },
        }

```
In first I got 
```
Warning  WARN [rest.nvim] Unrecognized configs found in setup: { "clients.curl.statistics.speed_download", "clients.curl.statistics.time_connect", "clients.curl.statistics.
speed_upload", "clients.curl.statistics.time_namelookup", "clients.curl.statistics.size_upload", "clients.curl.statistics.size_download.order", "clients.curl.statistics.time_total.order", "clie
nts.curl.statistics.remote_ip", "clients.curl.statistics.time_starttransfer", "clients.curl.statistics.time_redirect", "clients.curl.statistics.time_pretransfer" }
```

And after call request I got crash for winbar...
```
^I...al/share/nvim/lazy/rest.nvim/lua/rest-nvim/ui/result.lua:194: in function <...al/share/nvim/lazy/rest.nvim/lua/rest-nvim/ui/result.lua:181>
E15: Invalid expression: "v:lua.require('rest-nvim.ui.result').stat_winbar()"
2024-08-27T10:40:58 noice.nvim  ERROR vim/_editor.lua:0: nvim_exec2(): Vim(redraw):E15: Invalid expression: "v:lua.require('rest-nvim.ui.result').stat_winbar()
```


In this pr I fixed it, and add more pretty Statistics pane.


Before, default config
![image](https://github.com/user-attachments/assets/94cb78f6-feb9-4581-b1ed-eddb6c26c2f1)

After
default config:
![image](https://github.com/user-attachments/assets/281e3cb5-6849-418c-804e-2bb028e6f10c)

config:
```lua
        vim.g.rest_nvim = {
            clients = {
                curl = {
                    statistics = {
                        remote_ip = { winbar = "ip", title = "Remote IP", order = 1 },
                        time_total = { winbar = "time", title = "Time", order = 2 },
                        time_namelookup = { title = "Time dns", order = 3 },
                        time_connect = { title = "Time connect", order = 4 },
                        time_pretransfer = { title = "Time pretransfer", order = 5 },
                        time_redirect = { title = "Time redirect", order = 6 },
                        time_starttransfer = { title = "Time starttransfer", order = 7 },
                        size_download = { title = "Download size", winbar = false, order = 8 },
                        speed_download = { title = "Download speed", order = 9 },
                        size_upload = { title = "Upload size", order = 10 },
                        speed_upload = { title = "Upload speed", order = 11 },
                    },
                },
            },
        }

```
![image](https://github.com/user-attachments/assets/0e300c43-61d8-475e-990a-3332075c3c07)
