### PR TITLE
fix(ui): always use `rest_nvim_result` filetype (2nd attempt)

### DIFF
--- a/lua/rest-nvim/commands.lua
+++ b/lua/rest-nvim/commands.lua
@@ -100,7 +100,7 @@ local rest_command_tbl = {
     },
     run = {
         impl = function(args, opts)
-            if vim.bo.filetype ~= "http" or vim.b.__rest_no_http_file then
+            if vim.bo.filetype ~= "http" then
                 vim.notify(
                     "`:Rest run` can be only called from http file",
                     vim.log.levels.ERROR,

--- a/lua/rest-nvim/ui/result.lua
+++ b/lua/rest-nvim/ui/result.lua
@@ -20,9 +20,11 @@ end
 ---@param buffer integer
 ---@param filetype string
 local function syntax_highlight(buffer, filetype)
+    -- manually stop any attached tree-sitter parsers (#424, #429)
+    vim.treesitter.stop(buffer)
     local lang = vim.treesitter.language.get_lang(filetype)
     local ok = pcall(vim.treesitter.start, buffer, lang)
-    if not ok then
+    if not lang or not ok then
         vim.bo[buffer].syntax = filetype
     end
 end
@@ -59,11 +61,7 @@ local panes = {
                 set_lines(self.bufnr, { "No Request running" })
                 return
             end
-            -- HACK: `vim.treesitter.foldexpr()` finds fold based on filetype not registered parser of
-            -- current buffer
-            vim.bo[self.bufnr].filetype = "http"
-            vim.b[self.bufnr].__rest_no_http_file = true
-            -- syntax_highlight(self.bufnr, "http")
+            syntax_highlight(self.bufnr, "rest_nvim_result")
             local lines = render_request(data.request)
             if data.response then
                 logger.debug(data.response.status)

--- a/plugin/rest-nvim.lua
+++ b/plugin/rest-nvim.lua
@@ -72,5 +72,6 @@ vim.g.rest_nvim_deps = rest_nvim_deps
 
 require("rest-nvim.autocmds").setup()
 require("rest-nvim.commands").setup()
+vim.treesitter.language.register("http", "rest_nvim_result")
 
 vim.g.loaded_rest_nvim = true

--- a/queries/rest_nvim_result/folds.scm
+++ b/queries/rest_nvim_result/folds.scm
@@ -1,0 +1,1 @@
+; inherits http

--- a/queries/rest_nvim_result/highlights.scm
+++ b/queries/rest_nvim_result/highlights.scm
@@ -1,0 +1,1 @@
+; inherits http

--- a/queries/rest_nvim_result/injections.scm
+++ b/queries/rest_nvim_result/injections.scm
@@ -1,0 +1,1 @@
+; inherits http


### PR DESCRIPTION
fix #424
close #73 

Seems working, but I’ll take some time to ensure that this doesn’t break with other plugins like `nvim-treesitter` or `rocks-treesitter.nvim`