### PR TITLE
feat(gql): download schema

### DIFF
--- a/lua/rest-nvim/commands.lua
+++ b/lua/rest-nvim/commands.lua
@@ -98,6 +98,19 @@ local rest_command_tbl = {
             ui().enter(winnr)
         end,
     },
+    download_graphql_schema = {
+        impl = function()
+            if vim.bo.filetype ~= "http" or vim.b.__rest_no_http_file then
+                vim.notify(
+                    "`:Rest download_graphql_schema` can be only called from http file",
+                    vim.log.levels.ERROR,
+                    { title = "rest.nvim" }
+                )
+                return
+            end
+            request().download_graphql_schema()
+        end,
+    },
     run = {
         impl = function(args, opts)
             if vim.bo.filetype ~= "http" or vim.b.__rest_no_http_file then


### PR DESCRIPTION
Add a command to download a graphql schema.

The schema file is named after the buffer name,
without the .http extension with the suffix
.graphql-schema.json.

So if the name of the current buffer is `test.http`, the downloaded schema file would be named
`test.graphql-schema.json`.

Once such a schema file has been downloaded,
you can have autocompletions via kulala-cmp-graphql.nvim.

TODO: make the introspection query a dedicated file.

Closes #448 