### PR TITLE
fix: handle empty json responses

### DIFF
--- a/lua/rest-nvim/utils.lua
+++ b/lua/rest-nvim/utils.lua
@@ -322,8 +322,10 @@ function utils.gq_lines(lines, filetype)
         logger.debug(("can't find formatexpr or formatprg for %s filetype. Formatting is canceled"):format(filetype))
         return lines, false
     end
-    vim.api.nvim_buf_call(format_buf, function()
-        vim.cmd("silent normal gggqG")
+    pcall(function()
+        vim.api.nvim_buf_call(format_buf, function()
+            vim.cmd("silent normal gggqG")
+        end)
     end)
     local buf_lines = vim.api.nvim_buf_get_lines(format_buf, 0, -1, false)
     vim.api.nvim_buf_delete(format_buf, { force = true })


### PR DESCRIPTION
It is common to receive an `HTTP 401 Unauthorized` with an empty body when an API token is incorrect. While it's technically true that an empty string is not technically a valid JSON string, the result of this in rest.nvim is quite ungraceful. The user is given a huge messy error stack without any clear indication of what went wrong. And when the error message is closed by hitting enter, the results pane in rest.nvim is stuck in a "# Loading..." state and does not display the HTTP response code, making it very non-obvious what has gone wrong.

I reason that when this happens, it would be preferable to simply show the empty response and the 401 HTTP code because this is a preferable experience for the user. I'm very willing to believe there might be a more correct way to solve this problem, but this is what I came up with after a quick bit of wading around the codebase.

Below you can see the current user experience is versus what it looks like after the patch.

### Before
![image](https://github.com/user-attachments/assets/8854673e-f87a-485f-8670-ff1be4e32190)

![image](https://github.com/user-attachments/assets/847187b3-9a5b-4668-a05b-e50ab1105672)

### After
![image](https://github.com/user-attachments/assets/15070b19-5c5d-4295-b7cb-d250b7e0f1c0)
