### PR TITLE
fix: handle when format target is empty string (# 473)

### DIFF
--- a/lua/rest-nvim/utils.lua
+++ b/lua/rest-nvim/utils.lua
@@ -291,6 +291,10 @@ end
 ---@return boolean ok Whether formatting is done with `gq`
 function utils.gq_lines(lines, filetype)
     logger.debug("formatting with `gq`")
+    if #lines == 0 then
+        logger.debug("content is empty. Formatting is canceled")
+        return lines, true
+    end
     local format_buf = vim.api.nvim_create_buf(false, true)
     local ok, errmsg = pcall(vim.api.nvim_set_option_value, "filetype", filetype, { buf = format_buf })
     if not ok then

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -85,4 +85,8 @@ describe("gq_lines", function()
             "</note>",
         }, utils.gq_lines(lines, "xml"))
     end)
+    it("handle empty content #473", function()
+        local lines = {}
+        assert.same({}, utils.gq_lines(lines, "json"))
+    end)
 end)


### PR DESCRIPTION
reference: #473
