### PR TITLE
tree-sitter-http parser as luarocks dependency

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -31,6 +31,7 @@ jobs:
             mimetypes
             xml2lua
             fidget.nvim
+            tree-sitter-http == 0.0.33
           test_dependencies: |
             nlua
           copy_directories: |

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,4 @@ format:
 	stylua .
 
 test:
-	# TODO: install tree-sitter-http as a test dependency using nix
-	# or version it appart from NURR
-	# LUA_PATH="$(shell luarocks path --lr-path --lua-version 5.1 --local)" \
-	# LUA_CPATH="$(shell luarocks path --lr-cpath --lua-version 5.1 --local)" \
-	# luarocks install --local --lua-version 5.1 --dev tree-sitter-http
-	LUA_PATH="$(shell luarocks path --lr-path --lua-version 5.1 --local)" \
-	LUA_CPATH="$(shell luarocks path --lr-cpath --lua-version 5.1 --local)" \
 	luarocks test --local --lua-version 5.1 --dev

--- a/rest.nvim-scm-1.rockspec
+++ b/rest.nvim-scm-1.rockspec
@@ -25,6 +25,7 @@ dependencies = {
   "mimetypes",
   "xml2lua",
   "fidget.nvim",
+  "tree-sitter-http == 0.0.33",
 }
 
 test_dependencies = {


### PR DESCRIPTION
- **fix: handle localhost domains in cookies**
- **feat: use tree-sitter-http parser from luarocks dependency**
