### PR TITLE
feat(command): add uriencode/decode subcommands

### DIFF
--- a/lua/rest-nvim/client/curl_cli.lua
+++ b/lua/rest-nvim/client/curl_cli.lua
@@ -1,4 +1,5 @@
 local curl_cli = require("rest-nvim.client.curl.cli")
+local logger = require("rest-nvim.logger")
 
 local COMPATIBLE_METHODS = {
     "OPTIONS",
@@ -20,8 +21,9 @@ local client = {
     request = curl_cli.request,
     available = function(req)
         local method_ok = vim.list_contains(COMPATIBLE_METHODS, req.method)
-        local scheme = req.url:match("^(.+)://")
+        local scheme = req.url:match("^([^:]+)://")
         local scheme_ok = (not scheme) or scheme == "http" or scheme == "https"
+        logger.debug(("scheme %s not supported for curl_cli client"):format(scheme or "<nil>"))
         return method_ok and scheme_ok
     end,
 }

--- a/spec/client/client_spec.lua
+++ b/spec/client/client_spec.lua
@@ -1,0 +1,17 @@
+---@module 'luassert'
+
+local clients = require("rest-nvim.client")
+
+describe("request clients", function()
+    it("get_available_clients", function()
+        local req = {
+            method = "GET",
+            url = "https://duckduckgo.com?q=https://duckduckgo.com",
+            headers = {},
+            cookies = {},
+            handlers = {},
+        }
+        local available_clients = clients.get_available_clients(req)
+        assert.same(1, #available_clients)
+    end)
+end)


### PR DESCRIPTION
Waiting for Neovim v0.11 release because these subcommands are using `vim.fn.getregionpos()` api
