### PR TITLE
feat: add ability to pass certs

### DIFF
--- a/lua/rest-nvim/config/default.lua
+++ b/lua/rest-nvim/config/default.lua
@@ -49,6 +49,11 @@ local default_config = {
                 ---@type boolean Add `--compressed` argument when `Accept-Encoding` header includes
                 ---`gzip`
                 set_compressed = false,
+                ---@class rest.Config.Clients.Curl.Certificates
+                ---@field set_certificate_crt string
+                ---@field set_certificate_key string
+                ---@type table<string, rest.Config.Clients.Curl.Certificates>
+                certificates = nil,
             },
         },
     },


### PR DESCRIPTION
A key feature that is missing from what I can tell is the ability to pass a cert/key. This change request is to add a cert/key via configuration based on the host. If it matches that host, then the file path for the certs/keys will be added to the request.

Changes:
 - Add `--cert` and `--key` flag with file path to docs
 - Add a configuration setup so the keys are only sent with the corresponding request