### PR TITLE
Updates readme with latest certs feature that was missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ local default_config = {
                 ---@type boolean Add `--compressed` argument when `Accept-Encoding` header includes
                 ---`gzip`
                 set_compressed = false,
+                ---@type table<string, Certificate> Table containing certificates for each domains
+                certificates = {},
             },
         },
     },
@@ -197,6 +199,45 @@ local default_config = {
 }
 ```
 <!-- default-config:end -->
+
+#### Adding certificates for requests
+
+<!-- certs-config:start -->
+```lua
+---rest.nvim cert configuration
+---@class rest.Config
+local default_config = {
+    ---@class rest.Config.Clients
+    clients = {
+        ---@class rest.Config.Clients.Curl
+        curl = {
+            ---Statistics to be shown, takes cURL's `--write-out` flag variables
+            ---See `man curl` for `--write-out` flag
+            ---@type RestStatisticsStyle[]
+            statistics = {
+                { id = "time_total", winbar = "take", title = "Time taken" },
+                { id = "size_download", winbar = "size", title = "Download size" },
+            },
+            ---Curl-secific request/response hooks
+            ---@class rest.Config.Clients.Curl.Opts
+            opts = {
+                ---@type boolean Add `--compressed` argument when `Accept-Encoding` header includes
+                ---`gzip`
+                set_compressed = false,
+                ---@type table<string, Certificate> Table containing certificates for each domains
+                certificates = {
+                    ["your.domain.tld"] = {
+                        ---@field set_certificate_crt string
+                        set_certificate_crt = "/path/to/your.cert",
+                        ---@field set_certificate_key string
+                        set_certificate_key = "/path/to/your.cert"
+                    }
+                },
+            },
+        },
+    },
+```
+<!-- certs-config:end -->
 
 ## Usage
 

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -189,7 +189,7 @@ rest.Opts.Clients.Curl.Opts                        *rest.Opts.Clients.Curl.Opts*
                                              (Default: `false`)
         {certificates?}    (Certificates[])  Add `--cert` or `--key`  to the `curl` command when required with
                                              specific domains
-                                             (default: nil)
+                                             (default: table `{}`)
 
 
 RestStatisticsStyle                                        *RestStatisticsStyle*


### PR DESCRIPTION
In my previous [PR](https://github.com/rest-nvim/rest.nvim/pull/519), I missed updating the README.md and used the incorrect default in the vim docs.

Changes:
 - Updates `README.md` doc
 - vim doc fix