### PR TITLE
feat/interpret auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ local default_config = {
             user_agent = "rest.nvim v" .. require("rest-nvim.api").VERSION,
             ---@type boolean Set `Content-Type` header when it is empty and body is provided
             set_content_type = true,
+            ---@type boolean Interpret `Authorization` header when it is set in form of
+            ---"Basic username:password" or "Basic username password"
+            interpret_basic_auth = true,
         },
     },
     ---@class rest.Config.Response

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -148,10 +148,14 @@ rest.Opts.Request                                            *rest.Opts.Request*
 rest.Opts.Request.Hooks                                *rest.Opts.Request.Hooks*
 
     Fields: ~
-        {encode_url?}        (boolean)   Encode URL before making request (Default: `true`)
-        {user_agent?}        (string)    Set `User-Agent` header when it is empty. Set as empty string to disable.
-                                         (Default: `rest.nvim {version}`)
-        {set_content_type?}  (boolean)   Set `Content-Type` header when it is empty but request body is provided
+        {encode_url?}            (boolean)   Encode URL before making request (Default: `true`)
+        {user_agent?}            (string)    Set `User-Agent` header when it is empty. Set as empty string to disable.
+                                             (Default: `rest.nvim {version}`)
+        {set_content_type?}      (boolean)   Set `Content-Type` header when it is empty but request body is provided
+        {interpret_basic_auth?}  (boolean)   Interpret `Authorization` header when it is set in form of
+                                             "Basic username:password" or "Basic username password"
+                                             It will convert header to "Basic <base64-encoded-username:password>"
+                                             (Default: `true`)
 
 
 rest.Opts.Response                                          *rest.Opts.Response*

--- a/lua/rest-nvim/autocmds.lua
+++ b/lua/rest-nvim/autocmds.lua
@@ -81,6 +81,14 @@ function autocmds.setup()
                     end
                 end
             end
+            if hooks.interpret_basic_auth then
+                local auth_header = req.headers["authorization"]
+                if auth_header then
+                    local auth_header_value = auth_header[#auth_header]
+                    local id, pw = auth_header_value:match("Basic%s+([^:%s]+)%s*[:(%s+)]%s*(.*)")
+                    auth_header[#auth_header] = "Basic " .. require("base64").encode(id .. ":" .. pw)
+                end
+            end
         end,
     })
     vim.api.nvim_create_autocmd("User", {

--- a/lua/rest-nvim/config/default.lua
+++ b/lua/rest-nvim/config/default.lua
@@ -19,6 +19,9 @@ local default_config = {
             user_agent = "rest.nvim v" .. require("rest-nvim.api").VERSION,
             ---@type boolean Set `Content-Type` header when it is empty and body is provided
             set_content_type = true,
+            ---@type boolean Interpret `Authorization` header when it is set in form of
+            ---"Basic username:password" or "Basic username password"
+            interpret_basic_auth = true,
         },
     },
     ---@class rest.Config.Response

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -43,6 +43,11 @@ local config
 ---@field user_agent? string
 --- Set `Content-Type` header when it is empty but request body is provided
 ---@field set_content_type? boolean
+--- Interpret `Authorization` header when it is set in form of
+--- "Basic username:password" or "Basic username password"
+--- It will convert header to "Basic <base64-encoded-username:password>"
+--- (Default: `true`)
+---@field interpret_basic_auth? boolean
 
 ---@class rest.Opts.Response
 --- Default response hooks (aka. request handlers) configuration

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -20,6 +20,25 @@
         };
         disabled = luaOlder "5.1";
       }) {};
+    md5 = luaself.callPackage ({
+      buildLuarocksPackage,
+      fetchurl,
+      fetchzip,
+      luaOlder,
+    }:
+      buildLuarocksPackage {
+        pname = "md5";
+        version = "1.3-1";
+        knownRockspec = (fetchurl {
+          url    = "mirror://luarocks/md5-1.3-1.rockspec";
+          sha256 = "sha256-2S6Dvk0yazW8DCJf2DYxrLW11+B7r6DCJZ7CMCMAfSI=";
+        }).outPath;
+        src = fetchzip {
+          url    = "https://github.com/lunarmodules/md5/archive/refs/tags/1.3.zip";
+          sha256 = "sha256-mCN7mmCGf2vdXriT1q8rrhUmKh49AY8A+cZVCu6XJzY=";
+        };
+        disabled = luaOlder "5.0";
+      }) {};
     rest-nvim = luaself.callPackage ({
       buildLuarocksPackage,
       fetchurl,
@@ -39,6 +58,7 @@
           xml2lua
           fidget-nvim
           base64
+          md5
           tree-sitter-http
         ];
       }) {};

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -1,6 +1,25 @@
 { self }: final: prev: let
   luaPackages-override = luaself: luaprev: {
     tree-sitter-http = luaself.callPackage ./tree-sitter-http.nix {};
+    base64 = luaself.callPackage ({
+      buildLuarocksPackage,
+      fetchurl,
+      fetchzip,
+      luaOlder,
+    }:
+      buildLuarocksPackage {
+        pname = "base64";
+        version = "1.5-3";
+        knownRockspec = (fetchurl {
+          url    = "mirror://luarocks/base64-1.5-3.rockspec";
+          sha256 = "sha256-jMWugDDJMOfapPyEWVrC2frF24MSr8pLsNtwK9ejLwM=";
+        }).outPath;
+        src = fetchzip {
+          url    = "https://github.com/iskolbin/lbase64/archive/c261320edbdf82c16409d893a96c28c704aa0ab8.zip";
+          sha256 = "sha256-Ucu7pxEbyeUyV12+FeFbGNhXiKsGYlXFMrb1Vhsnfrc=";
+        };
+        disabled = luaOlder "5.1";
+      }) {};
     rest-nvim = luaself.callPackage ({
       buildLuarocksPackage,
       fetchurl,
@@ -19,6 +38,7 @@
           mimetypes
           xml2lua
           fidget-nvim
+          base64
           tree-sitter-http
         ];
       }) {};

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -14,6 +14,7 @@
           mimetypes
           xml2lua
           fidget-nvim
+          final.lua51Packages.base64
           final.lua51Packages.tree-sitter-http
         ];
       extraPackages = [

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -15,6 +15,7 @@
           xml2lua
           fidget-nvim
           final.lua51Packages.base64
+          final.lua51Packages.md5
           final.lua51Packages.tree-sitter-http
         ];
       extraPackages = [

--- a/rest.nvim-scm-1.rockspec
+++ b/rest.nvim-scm-1.rockspec
@@ -25,6 +25,7 @@ dependencies = {
   "mimetypes",
   "xml2lua",
   "fidget.nvim",
+  "base64",
   "tree-sitter-http == 0.0.35",
 }
 

--- a/spec/examples/examples_spec.lua
+++ b/spec/examples/examples_spec.lua
@@ -119,4 +119,42 @@ describe("builtin request hooks", function()
             assert.same({ "application/json" }, req.headers["content-type"])
         end)
     end)
+    ---@return rest.Request
+    local function sample_request(opts)
+        return vim.tbl_deep_extend("keep", opts, {
+            method = "GET",
+            url = "https://example.com",
+            headers = {},
+            cookies = {},
+            handlers = {},
+        })
+    end
+    describe("interpret_basic_auth", function()
+        it("with valid vscode style token", function()
+            local req = sample_request({
+                headers = {
+                    ["authorization"] = { "Basic username:password" },
+                },
+            })
+            _G.rest_request = req
+            vim.api.nvim_exec_autocmds("User", {
+                pattern = { "RestRequest", "RestRequestPre" },
+            })
+            _G.rest_request = nil
+            assert.same({ "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" }, req.headers["authorization"])
+        end)
+        it("with valid intellij style token", function()
+            local req = sample_request({
+                headers = {
+                    ["authorization"] = { "Basic username password" },
+                },
+            })
+            _G.rest_request = req
+            vim.api.nvim_exec_autocmds("User", {
+                pattern = { "RestRequest", "RestRequestPre" },
+            })
+            _G.rest_request = nil
+            assert.same({ "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" }, req.headers["authorization"])
+        end)
+    end)
 end)

--- a/spec/examples/examples_spec.lua
+++ b/spec/examples/examples_spec.lua
@@ -158,3 +158,9 @@ describe("builtin request hooks", function()
         end)
     end)
 end)
+it("make sure md5 work", function()
+    local md5 = require("md5")
+    local md5sum = md5.sumhexa
+    assert.same("9236657b478ea807fdfa275d24990843", md5sum("qwer:asdf"))
+    -- TODO: implement digest auth with https://github.com/catwell/lua-http-digest/blob/master/http-digest.lua
+end)


### PR DESCRIPTION
Implement `Basic` and `Digest` authorization tokens which are both supported in intellij's http client.

Fixes #483
