### PR TITLE
fix: run request before UI open

### DIFF
--- a/lua/rest-nvim/commands.lua
+++ b/lua/rest-nvim/commands.lua
@@ -121,8 +121,8 @@ local rest_command_tbl = {
                 return
             end
             ui().clear()
-            open_result_ui(opts)
             request().run(args[1])
+            open_result_ui(opts)
         end,
         ---@return string[]
         complete = function(args)

--- a/lua/rest-nvim/request.lua
+++ b/lua/rest-nvim/request.lua
@@ -58,11 +58,10 @@ local function run_request(req)
     })
     _G.rest_request = nil
 
-    ui.update({ request = req })
-
     -- NOTE: wrap with schedule to do vim stuffs outside of lua callback loop (`on_exit`
     -- callback from `vim.system()` call)
     nio.run(function()
+        ui.update({ request = req })
         local ok, res = pcall(client.request(req).wait)
         if not ok then
             logger.error("request failed")


### PR DESCRIPTION
Run request before opening window which can lead unwanted cursor move when `'splitkeep'` is not `topline`.

Fixes #464
