### PR TITLE
Fix Statistics syntax highlight

### DIFF
--- a/lua/rest-nvim/ui/result.lua
+++ b/lua/rest-nvim/ui/result.lua
@@ -23,7 +23,7 @@ local function syntax_highlight(buffer, filetype)
     -- manually stop any attached tree-sitter parsers (#424, #429)
     vim.treesitter.stop(buffer)
     local lang = vim.treesitter.language.get_lang(filetype)
-    local ok = pcall(vim.treesitter.start, buffer, lang)
+    local ok = lang ~= nil and pcall(vim.treesitter.start, buffer, lang)
     if not lang or not ok then
         vim.bo[buffer].syntax = filetype
     end


### PR DESCRIPTION
The Statistics syntax highlight is broken due to missing "http_stat" treesitter language. Not starting treesitter when the language is missing will fallback to the "http_stat" vim syntax defined in the project.

Before:
![before](https://github.com/user-attachments/assets/230aa014-e6a1-4bc3-a80e-40aedcbcadd6)

After:
![after](https://github.com/user-attachments/assets/c207b5fc-f56c-4b61-b2c7-fa0b70f8ac0b)

