### PR TITLE
feat: allow $dotenv tags in variables

### DIFF
--- a/lua/rest-nvim/parser/init.lua
+++ b/lua/rest-nvim/parser/init.lua
@@ -47,6 +47,8 @@ end
 ---@return string
 ---@return integer
 local function expand_variables(src, context)
+    -- remove $dotenv tags, which are used by the vscode rest client for cross compatibility
+    src = src:gsub("%$dotenv ", ""):gsub("%$DOTENV ", "")
     return src:gsub("{{(.-)}}", function(name)
         name = vim.trim(name)
         local res = context:resolve(name)


### PR DESCRIPTION
This is essentially the same change as in this commit https://github.com/rest-nvim/rest.nvim/commit/9800b593034770fee5eb460ff0e8f0b13de83300

With this change,  [in place variables](https://www.jetbrains.com/help/idea/exploring-http-syntax.html#in-place-variables) can be defined like this


```http
@token={{$dotenv TOKEN}} 
```