### PR TITLE
Fix year issue

### DIFF
--- a/lua/rest-nvim/utils.lua
+++ b/lua/rest-nvim/utils.lua
@@ -83,6 +83,14 @@ function utils.read_file(path)
     return content
 end
 
+local function fix_year(year)
+    if year < 100 then
+        return year + 2000
+    end
+
+    return year
+end
+
 function utils.parse_http_time(time_str)
     local pattern = "(%a+), (%d+)[%s-](%a+)[%s-](%d+) (%d+):(%d+):(%d+) GMT"
     local _, day, month_name, year, hour, min, sec = time_str:match(pattern)
@@ -92,7 +100,7 @@ function utils.parse_http_time(time_str)
     Jul = 7, Aug = 8, Sep = 9, Oct = 10, Nov = 11, Dec = 12,
   }
     local time_table = {
-        year = tonumber(year),
+        year = fix_year(tonumber(year)),
         month = months[month_name],
         day = tonumber(day),
         hour = tonumber(hour),


### PR DESCRIPTION
Found this while running some http request

```
Error executing vim.schedule lua callback: ...eem/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message: 
....local/share/nvim/lazy/rest.nvim/lua/rest-nvim/utils.lua:105: attempt to perform arithmetic on a nil value
stack traceback:
	....local/share/nvim/lazy/rest.nvim/lua/rest-nvim/utils.lua: in function 'parse_http_time'
	...l/share/nvim/lazy/rest.nvim/lua/rest-nvim/cookie_jar.lua:81: in function 'f'
	...Cellar/neovim/0.11.4/share/nvim/runtime/lua/vim/iter.lua:335: in function 'map'
	...l/share/nvim/lazy/rest.nvim/lua/rest-nvim/cookie_jar.lua:134: in function 'update_jar'
	...ocal/share/nvim/lazy/rest.nvim/lua/rest-nvim/request.lua:89: in function 'run_request'
	...ocal/share/nvim/lazy/rest.nvim/lua/rest-nvim/request.lua:120: in function <...ocal/share/nvim/lazy/rest.nvim/lua/rest-nvim/request.lua:109>
stack traceback:
	[C]: in function 'error'
	...eem/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:100: in function 'close_task'
	...eem/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:122: in function 'cb'
	...eem/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:183: in function 'waiter'
	...m/.local/share/nvim/lazy/nvim-nio/lua/nio/control.lua:116: in function 'wake'
	...m/.local/share/nvim/lazy/nvim-nio/lua/nio/control.lua:129: in function 'set'
	...re/nvim/lazy/rest.nvim/lua/rest-nvim/client/curl/cli.lua:382: in function <...re/nvim/lazy/rest.nvim/lua/rest-nvim/client/curl/cli.lua:376>
```

Seems that server give this back on the Cookie `Tue, 07-Oct-25 10:40:55 GMT`. Looks like it's an old format from RFC 850. So that hopefully this to handle the old server behavior without breaking the existing logic.
