### PR TITLE
feat: Add support for user-defined comment directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ vim.g.rest_nvim = {
 local default_config = {
     ---@type table<string, fun():string> Table of custom dynamic variables
     custom_dynamic_variables = {},
+    ---@type table<string, rest.Opts.DirectiveFn> Table of custom directives
+    custom_directives = {},
     ---@class rest.Config.Request
     request = {
         ---@type boolean Skip SSL verification, useful for unknown certificates

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ vim.g.rest_nvim = {
 local default_config = {
     ---@type table<string, fun():string> Table of custom dynamic variables
     custom_dynamic_variables = {},
-    ---@type table<string, rest.Opts.DirectiveFn> Table of custom directives
+    ---@type rest.Opts.Directives Table of custom directives
     custom_directives = {},
     ---@class rest.Config.Request
     request = {

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -130,6 +130,7 @@ rest.Opts                                                            *rest.Opts*
 
     Fields: ~
         {custom_dynamic_variables?}  (table<string,fun():string>)   Table of custom dynamic variables
+        {custom_directives?}         (rest.Opts.Directives)         Table of custom directives
         {request?}                   (rest.Opts.Request)
         {response?}                  (rest.Opts.Response)
         {clients?}                   (rest.Opts.Clients)
@@ -137,6 +138,17 @@ rest.Opts                                                            *rest.Opts*
         {env?}                       (rest.Opts.Env)
         {ui?}                        (rest.Opts.UI)
         {highlight?}                 (rest.Opts.Highlight)
+
+
+rest.Opts.Directives                                      *rest.Opts.Directives*
+     Custom directive handlers, keyed by directive name.
+     Each handler receives the request context and space-separated arguments
+     from the comment. For example, given:
+       `custom_directives = { var = function(ctx, name, value) ctx:set_local(name, value) end }`
+     then `# @var foo bar` is equivalent to `@foo = bar`.
+
+    Type: ~
+        table
 
 
 rest.Opts.Request                                            *rest.Opts.Request*

--- a/lua/rest-nvim/config/check.lua
+++ b/lua/rest-nvim/config/check.lua
@@ -44,6 +44,7 @@ function check.validate(cfg)
     compat_deprecated(cfg)
     local ok, err = validate({
         custom_dynamic_variables = { cfg.custom_dynamic_variables, "table" },
+        custom_directives = { cfg.custom_directives, "table" },
         request = { cfg.request, "table" },
         ["request.skip_ssl_verification"] = { cfg.request.skip_ssl_verification, "boolean" },
         ["request.hooks"] = { cfg.request.hooks, "table" },

--- a/lua/rest-nvim/config/default.lua
+++ b/lua/rest-nvim/config/default.lua
@@ -6,7 +6,7 @@
 local default_config = {
     ---@type table<string, fun():string> Table of custom dynamic variables
     custom_dynamic_variables = {},
-    ---@type table<string, rest.Opts.DirectiveFn> Table of custom directives
+    ---@type rest.Opts.Directives Table of custom directives
     custom_directives = {},
     ---@class rest.Config.Request
     request = {
@@ -42,7 +42,7 @@ local default_config = {
             ---See `man curl` for `--write-out` flag
             ---@type RestStatisticsStyle[]
             statistics = {
-                { id = "time_total", winbar = "take", title = "Time taken" },
+                { id = "time_total",    winbar = "take", title = "Time taken" },
                 { id = "size_download", winbar = "size", title = "Download size" },
             },
             ---Curl-secific request/response hooks

--- a/lua/rest-nvim/config/default.lua
+++ b/lua/rest-nvim/config/default.lua
@@ -42,7 +42,7 @@ local default_config = {
             ---See `man curl` for `--write-out` flag
             ---@type RestStatisticsStyle[]
             statistics = {
-                { id = "time_total",    winbar = "take", title = "Time taken" },
+                { id = "time_total", winbar = "take", title = "Time taken" },
                 { id = "size_download", winbar = "size", title = "Download size" },
             },
             ---Curl-secific request/response hooks

--- a/lua/rest-nvim/config/default.lua
+++ b/lua/rest-nvim/config/default.lua
@@ -6,6 +6,8 @@
 local default_config = {
     ---@type table<string, fun():string> Table of custom dynamic variables
     custom_dynamic_variables = {},
+    ---@type table<string, rest.Opts.DirectiveFn> Table of custom directives
+    custom_directives = {},
     ---@class rest.Config.Request
     request = {
         ---@type boolean Skip SSL verification, useful for unknown certificates

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -21,6 +21,8 @@ local config
 ---@class rest.Opts
 --- Table of custom dynamic variables
 ---@field custom_dynamic_variables? table<string, fun():string>
+--- Table of custom directives
+---@field custom_directives? rest.Opts.Directives
 ---@field request? rest.Opts.Request
 ---@field response? rest.Opts.Response
 ---@field clients? rest.Opts.Clients
@@ -28,6 +30,13 @@ local config
 ---@field env? rest.Opts.Env
 ---@field ui? rest.Opts.UI
 ---@field highlight? rest.Opts.Highlight
+
+--- Custom directive handlers, keyed by directive name.
+--- Each handler receives the request context and space-separated arguments
+--- from the comment. For example, given:
+---   `custom_directives = { var = function(ctx, name, value) ctx:set_local(name, value) end }`
+--- then `# @var foo bar` is equivalent to `@foo = bar`.
+---@alias rest.Opts.Directives table<string, fun(ctx: rest.Context, ...: string)>
 
 ---@class rest.Opts.Request
 --- Skip SSL verification, useful for unknown certificates (Default: `false`)

--- a/lua/rest-nvim/parser/init.lua
+++ b/lua/rest-nvim/parser/init.lua
@@ -14,6 +14,7 @@ local utils = require("rest-nvim.utils")
 local logger = require("rest-nvim.logger")
 local jar = require("rest-nvim.cookie_jar")
 local nio = require("nio")
+local config = require("rest-nvim.config")
 
 ---@alias Source integer|string Buffer or string which the `node` is extracted
 
@@ -475,6 +476,9 @@ function parser.parse(node, source, ctx)
                 if input then
                     ctx:set_local(var_name, input)
                 end
+            elseif config.custom_directives[comment_name] ~= nil and comment_value then
+                local args = vim.split(comment_value, ' +')
+                config.custom_directives[comment_name](ctx, unpack(args))
             end
         elseif child_type == "variable_declaration" then
             parser.parse_variable_declaration(child, source, ctx)

--- a/spec/parser/http_parser_spec.lua
+++ b/spec/parser/http_parser_spec.lua
@@ -6,6 +6,7 @@ local parser = require("rest-nvim.parser")
 local utils = require("rest-nvim.utils")
 local context = require("rest-nvim.context").Context
 local logger = require("rest-nvim.logger")
+local config = require("rest-nvim.config")
 
 local spy = require("luassert.spy")
 
@@ -364,6 +365,84 @@ foo={{VAR}}
                 foo = "bar",
                 baz = "bar " .. os.date("%Y-%m-%d"),
             }, c.vars)
+        end)
+    end)
+
+    describe("custom directives", function()
+        local source = [[### test request
+# @mydir foo bar baz
+GET http://localhost
+]]
+
+        after_each(function()
+            config.custom_directives = nil
+        end)
+
+        it("registered directive handler is called", function()
+            local called = false
+            config.custom_directives = {
+                mydir = function(_ctx, ...)
+                    called = true
+                end,
+            }
+
+            local _, tree = utils.ts_parse_source(source)
+            local req_node = assert(tree:root():child(0))
+            parser.parse(req_node, source)
+
+            assert.is_true(called)
+        end)
+
+        it("handler receives correct varargs", function()
+            local received = {}
+            config.custom_directives = {
+                mydir = function(_ctx, ...)
+                    received = { ... }
+                end,
+            }
+
+            local _, tree = utils.ts_parse_source(source)
+            local req_node = assert(tree:root():child(0))
+            parser.parse(req_node, source)
+
+            assert.same({ "foo", "bar", "baz" }, received)
+        end)
+
+        it("handler can set a variable resolved in request", function()
+            config.custom_directives = {
+                mydir = function(ctx, var_name, value)
+                    ctx:set_local(var_name, value)
+                end,
+            }
+            local src = [[### test request
+# @mydir token secret123
+GET http://localhost/{{token}}
+]]
+
+            local _, tree = utils.ts_parse_source(src)
+            local req_node = assert(tree:root():child(0))
+            local req = assert(parser.parse(req_node, src))
+
+            assert.same("http://localhost/secret123", req.url)
+        end)
+
+        it("unknown directive is silently ignored", function()
+            local called = false
+            config.custom_directives = {
+                foo = function()
+                    called = true
+                end
+            }
+            local spy_log_error = spy.on(logger, "error")
+
+            local _, tree = utils.ts_parse_source(source)
+            local req_node = assert(tree:root():child(0))
+            local req = parser.parse(req_node, source)
+
+            assert.is_false(called)
+            assert.not_nil(req)
+            ---@diagnostic disable-next-line: undefined-field
+            assert.spy(spy_log_error).was_not_called()
         end)
     end)
 


### PR DESCRIPTION
Adds a `custom_directives` config option that lets users register handlers for `# @directive` comments.

This would be a table of keyed functions where the key is the directive and the function gets called with the space separated arguments that follow.

For example, given:
```
custom_directives = { var = function(ctx, name, value) ctx:set_local(name, value) end }
```
`# @var foo bar` would be equivalent to `@foo = bar`.

Personally I'd find this very useful for securely getting values out of my password store (example below). But I see this being quite useful in general. And as you can see the implementation is really quite simple.
Of course, you could technically achieve something similar with a post-request script. This feature is more so to handle the case where you want to do mostly the same action many times or in many places, at that point copy-pasting the script around becomes very verbose and not to mention hard to maintain.

Password store example:
```lua
vim.g.rest_nvim = {
  custom_directives = {
    pass = function(ctx, variable, pass_name)
      if not (variable and pass_name) then
        print('Directive @pass expects exactly 2 arguments')
        return
      end

      local cmd = { 'pass', 'show', pass_name }
      local result = vim.system(cmd, { text = true }):wait()

      if result.code ~= 0 then
        print('Failed to get password \'' .. pass_name .. '\': ' ..
          vim.trim(result.stdout) .. vim.trim(result.stderr))
        return
      end

      ctx:set_local(variable, vim.trim(result.stdout))
    end
  }
}
```
Then:
```http
# @pass token secret/api/key
GET https://api.example.com
Authorization: Bearer {{token}}
```